### PR TITLE
More Reliable GasOracle

### DIFF
--- a/src/chains/ethereum.ts
+++ b/src/chains/ethereum.ts
@@ -14,6 +14,7 @@ import {
 import { NO_DEPOSIT, getNearAccount, provider as nearProvider } from "./near";
 import { GasPriceResponse, GasPrices, TxPayload } from "../types";
 import { getMultichainContract } from "../mpc_contract";
+import { getFirstNonZeroGasPrice } from "../utils/gasPrice";
 
 const config = {
   chainId: 11155111,
@@ -43,9 +44,8 @@ async function queryGasPrice(): Promise<GasPrices> {
   const res = await fetch(
     "https://sepolia.beaconcha.in/api/v1/execution/gasnow"
   );
-  const json = await res.json() as GasPriceResponse;
-  console.log("Response", json);
-  const maxPriorityFeePerGas = BigInt(json.data.rapid);
+  const gasPrices = await res.json() as GasPriceResponse;
+  const maxPriorityFeePerGas = BigInt(getFirstNonZeroGasPrice(gasPrices)!);
 
   // Since we don't have a direct `baseFeePerGas`, we'll use a workaround.
   // Ideally, you should fetch the current `baseFeePerGas` from the network.

--- a/src/utils/gasPrice.ts
+++ b/src/utils/gasPrice.ts
@@ -1,0 +1,17 @@
+import { GasPriceResponse } from "../types";
+
+
+export const getFirstNonZeroGasPrice = (response: GasPriceResponse): number | undefined => {
+  // List the properties we're interested in
+  const properties: (keyof GasPriceResponse["data"])[] = ["rapid", "fast", "standard", "slow"];
+
+  // Iterate through the properties and return the first non-zero value
+  for (const property of properties) {
+    if (response.data[property] !== 0) {
+      return response.data[property];
+    }
+  }
+
+  // Return undefined if all values are zero or if none are found
+  return undefined;
+};


### PR DESCRIPTION
While this is still sepolia specific, we choose the first non-zero gas price from the following endpoint:

https://sepolia.beaconcha.in/api/v1/execution/gasnow

Note that we will have to build more advanced gas stuff (e.g. gnosischain has a different response type here: https://gnosis.blockscout.com/api/v1/gas-price-oracle)
