### PR TITLE
Fix sender on EVM instance construction

### DIFF
--- a/examples/opensea.ts
+++ b/examples/opensea.ts
@@ -43,9 +43,8 @@ const run = async (slug: string): Promise<void> => {
   // This sleep is due to free-tier testnet rate limiting.
   await sleep(1000);
   const evm = await setupNearEthConnection();
-  const sender = await evm.getSender();
   const data = await openseaSDK.api.generateFulfillmentData(
-    sender,
+    evm.sender,
     cheapestAvailable.order_hash,
     cheapestAvailable.protocol_address,
     OrderSide.ASK

--- a/examples/setup.ts
+++ b/examples/setup.ts
@@ -7,7 +7,7 @@ dotenv.config();
 export async function setupNearEthConnection(): Promise<EVM> {
   // This also reads from process.env!
   const account = await getNearAccount();
-  return new EVM({
+  return EVM.fromConfig({
     providerUrl: process.env.NODE_URL!,
     scanUrl: process.env.SCAN_URL!,
     gasStationUrl: process.env.GAS_STATION_URL!,
@@ -15,5 +15,6 @@ export async function setupNearEthConnection(): Promise<EVM> {
       account,
       process.env.NEAR_MULTICHAIN_CONTRACT!
     ),
+    derivationPath: "ethereum,1",
   });
 }

--- a/examples/transfer-1155.ts
+++ b/examples/transfer-1155.ts
@@ -9,12 +9,11 @@ const run = async (): Promise<void> => {
   const tokenAddress = "0x284c37b0fcb72034ff25855da57fcf097b255474";
   const tokenId = 1;
   const to = "0x8d99F8b2710e6A3B94d9bf465A98E5273069aCBd";
-  const from = await evm.getSender();
 
   const callData = encodeFunctionData({
     abi: erc1155Abi,
     functionName: "safeTransferFrom(address,address,uint256,uint256,bytes)",
-    args: [from, to, tokenId, 1, "0x"],
+    args: [evm.sender, to, tokenId, 1, "0x"],
   });
 
   await evm.signAndSendTransaction({

--- a/examples/transfer-nft.ts
+++ b/examples/transfer-nft.ts
@@ -4,7 +4,6 @@ import { setupNearEthConnection } from "./setup";
 
 const run = async (): Promise<void> => {
   const evm = await setupNearEthConnection();
-  const sender = await evm.getSender();
   const amount = 0;
   // TODO retrieve from user:
   const tokenAddress = "0xb5EF4EbB25fCA7603C028610ddc9233d399dA34d";
@@ -14,7 +13,7 @@ const run = async (): Promise<void> => {
   const callData = encodeFunctionData({
     abi: erc721ABI,
     functionName: "safeTransferFrom(address,address,uint256)",
-    args: [sender, to, tokenId],
+    args: [evm.sender, to, tokenId],
   });
 
   await evm.signAndSendTransaction({


### PR DESCRIPTION
It was dangerous to be throwing around a non-fixed derivation path. Now this is fixed along with associated sender.