### PR TITLE
Chain Agnostic Adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,3 @@
 NEAR_ACCOUNT_ID=
 NEAR_ACCOUNT_PRIVATE_KEY=
 NEAR_MULTICHAIN_CONTRACT=multichain-testnet-2.testnet
-
-NODE_URL=https://rpc.sepolia.org
-SCAN_URL=https://sepolia.etherscan.io
-GAS_STATION_URL=https://sepolia.beaconcha.in/api/v1/execution/gasnow

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **DISCLAIMER: This should only be used for educational purposes.**
 
-NEAR-CA is a TypeScript library that provides an abstraction layer for interacting with the NEAR blockchain. It simplifies the process of performing transactions and managing accounts on NEAR and Ethereum chains. 
+NEAR-CA is a TypeScript library that provides an abstraction layer for interacting with the NEAR blockchain. It simplifies the process of performing transactions and managing accounts on NEAR and Ethereum chains.
 
 Intended to be used on server-side applications only.
 
@@ -41,39 +41,35 @@ For Ethereum, you can derive addresses, create payloads for transactions, and se
 
 ```typescript
 import dotenv from "dotenv";
-import { MultichainContract, NearEthAdapter, nearAccountFromEnv } from "near-ca";
+import {
+  MultichainContract,
+  NearEthAdapter,
+  nearAccountFromEnv,
+} from "near-ca";
 
 dotenv.config();
 // Could also import and use nearAccountFromKeyPair here ;)
 const account = await nearAccountFromEnv();
-// Near Config
-const near = {
-    mpcContract: new MultichainContract(
-        account,
-        process.env.NEAR_MULTICHAIN_CONTRACT!
-    ),
-    derivationPath: "ethereum,1",
-};
 
-// EVM Config
-const evm = {
-    providerUrl: process.env.NODE_URL!,
-    scanUrl: process.env.SCAN_URL!,
-    gasStationUrl: process.env.GAS_STATION_URL!,
-};
+const adapter = await NearEthAdapter.fromConfig({
+  mpcContract: new MultichainContract(
+    account,
+    process.env.NEAR_MULTICHAIN_CONTRACT!
+  ),
+  derivationPath: "ethereum,1",
+});
 
-const neareth = await NearEthAdapter.fromConfig({ near, evm });
-
-await neareth.signAndSendTransaction({
-    receiver: "0xdeADBeeF0000000000000000000000000b00B1e5",
-    amount: 0.00000001,
-    // Optional Set nearGas (default is 200 TGAS - which still sometimes doesn't work!)
+await adapter.signAndSendTransaction({
+  receiver: "0xdeADBeeF0000000000000000000000000b00B1e5",
+  amount: 0.00000001,
+  chainId: 11_155_111,
+  // Optional Set nearGas (default is 200 TGAS - which still sometimes doesn't work!)
 });
 ```
 
 ### Other Examples
 
-Each of the following scripts can be run with 
+Each of the following scripts can be run with
 
 ```bash
 npx ts-node examples/*.ts
@@ -81,8 +77,8 @@ npx ts-node examples/*.ts
 
 1. [(Basic) Send ETH](./examples/send-eth.ts)
 2. **WETH**
-    - [Deposit (aka wrap-ETH)](./examples/weth/wrap.ts)
-    - [Withdraw (aka unwrap-ETH)](./examples/weth/wrap.ts)
+   - [Deposit (aka wrap-ETH)](./examples/weth/wrap.ts)
+   - [Withdraw (aka unwrap-ETH)](./examples/weth/wrap.ts)
 3. [Transfer ERC721](./examples/nft/erc721/transfer.ts)
 4. [(Advanced) Buy NFT On Opensea](./examples/opensea.ts)
 
@@ -93,8 +89,5 @@ Before using NEAR-CA, ensure you have the following environment variables set:
 - `NEAR_ACCOUNT_ID`: Your NEAR account identifier.
 - `NEAR_ACCOUNT_PRIVATE_KEY`: Your NEAR account private key.
 - `NEAR_MULTICHAIN_CONTRACT`: The NEAR contract that handles multichain operations.
-- `NODE_URL=https://rpc.sepolia.org`
-- `SCAN_URL=https://sepolia.etherscan.io`
-- `GAS_STATION_URL=https://sepolia.beaconcha.in/api/v1/execution/gasnow`
 
 Copy the `.env.example` file and place these values in `.env`

--- a/examples/nft/erc1155/transfer.ts
+++ b/examples/nft/erc1155/transfer.ts
@@ -1,5 +1,5 @@
 import erc1155Abi from "../../abis/ERC1155.json";
-import { setupNearEthAdapter } from "../../setup";
+import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "../../setup";
 import { encodeFunctionData } from "viem";
 
 const run = async (): Promise<void> => {
@@ -12,12 +12,13 @@ const run = async (): Promise<void> => {
   const callData = encodeFunctionData({
     abi: erc1155Abi,
     functionName: "safeTransferFrom(address,address,uint256,uint256,bytes)",
-    args: [evm.ethPublicKey(), to, tokenId, 1, "0x"],
+    args: [evm.address, to, tokenId, 1, "0x"],
   });
 
   await evm.signAndSendTransaction({
     to: tokenAddress,
     data: callData,
+    chainId: SEPOLIA_CHAIN_ID,
   });
 };
 

--- a/examples/nft/erc721/mint.ts
+++ b/examples/nft/erc721/mint.ts
@@ -1,5 +1,5 @@
 import { encodeFunctionData } from "viem";
-import { setupNearEthAdapter } from "../../setup";
+import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "../../setup";
 
 const run = async (): Promise<void> => {
   const adapter = await setupNearEthAdapter();
@@ -11,6 +11,7 @@ const run = async (): Promise<void> => {
       functionName: "safeMint",
       args: ["0xAA5FcF171dDf9FE59c985A28747e650C2e9069cA"],
     }),
+    chainId: SEPOLIA_CHAIN_ID,
   });
 };
 

--- a/examples/nft/erc721/transfer.ts
+++ b/examples/nft/erc721/transfer.ts
@@ -1,6 +1,6 @@
 import erc721ABI from "../../abis/ERC721.json";
 import { encodeFunctionData } from "viem";
-import { setupNearEthAdapter } from "../../setup";
+import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "../../setup";
 
 const run = async (): Promise<void> => {
   const neareth = await setupNearEthAdapter();
@@ -14,8 +14,9 @@ const run = async (): Promise<void> => {
     data: encodeFunctionData({
       abi: erc721ABI,
       functionName: "safeTransferFrom(address,address,uint256)",
-      args: [neareth.ethPublicKey(), to, tokenId],
+      args: [neareth.address, to, tokenId],
     }),
+    chainId: SEPOLIA_CHAIN_ID,
   });
 };
 

--- a/examples/nft/setApprovalForAll.ts
+++ b/examples/nft/setApprovalForAll.ts
@@ -1,6 +1,6 @@
 import erc721ABI from "../abis/ERC721.json";
 import { encodeFunctionData } from "viem";
-import { setupNearEthAdapter } from "../setup";
+import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "../setup";
 
 const run = async (): Promise<void> => {
   const neareth = await setupNearEthAdapter();
@@ -14,6 +14,7 @@ const run = async (): Promise<void> => {
       functionName: "setApprovalForAll",
       args: [operator, true],
     }),
+    chainId: SEPOLIA_CHAIN_ID,
   });
 };
 

--- a/examples/opensea.ts
+++ b/examples/opensea.ts
@@ -1,5 +1,5 @@
 import { OpenSeaSDK, Chain, OrderSide } from "opensea-js";
-import { setupNearEthAdapter, sleep } from "./setup";
+import { SEPOLIA_CHAIN_ID, setupNearEthAdapter, sleep } from "./setup";
 import * as readline from "readline";
 import { ethers } from "ethers";
 import { Address, Hex, encodeFunctionData } from "viem";
@@ -39,7 +39,7 @@ const run = async (slug: string): Promise<void> => {
   // This sleep is due to free-tier testnet rate limiting.
   await sleep(1000);
   const data = await openseaSDK.api.generateFulfillmentData(
-    evm.ethPublicKey(),
+    evm.address,
     cheapestAvailable.order_hash,
     cheapestAvailable.protocol_address,
     OrderSide.ASK
@@ -74,6 +74,7 @@ const run = async (slug: string): Promise<void> => {
     to: tx.to as Address,
     value: BigInt(tx.value),
     data: callData as Hex,
+    chainId: SEPOLIA_CHAIN_ID,
   });
 };
 

--- a/examples/send-eth.ts
+++ b/examples/send-eth.ts
@@ -1,5 +1,5 @@
 import dotenv from "dotenv";
-import { setupNearEthAdapter } from "./setup";
+import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "./setup";
 dotenv.config();
 
 const run = async (): Promise<void> => {
@@ -8,6 +8,7 @@ const run = async (): Promise<void> => {
     to: "0xdeADBeeF0000000000000000000000000b00B1e5",
     // THIS IS ONE WEI!
     value: 1n,
+    chainId: SEPOLIA_CHAIN_ID,
   });
 };
 

--- a/examples/setup.ts
+++ b/examples/setup.ts
@@ -1,22 +1,17 @@
 import dotenv from "dotenv";
 import { MultichainContract, NearEthAdapter, nearAccountFromEnv } from "../src";
 
+export const SEPOLIA_CHAIN_ID = 11_155_111;
+
 export async function setupNearEthAdapter(): Promise<NearEthAdapter> {
   dotenv.config();
   const account = await nearAccountFromEnv();
   return NearEthAdapter.fromConfig({
-    evm: {
-      providerUrl: process.env.NODE_URL!,
-      scanUrl: process.env.SCAN_URL!,
-      gasStationUrl: process.env.GAS_STATION_URL!,
-    },
-    near: {
-      mpcContract: new MultichainContract(
-        account,
-        process.env.NEAR_MULTICHAIN_CONTRACT!
-      ),
-      derivationPath: "ethereum,1",
-    },
+    mpcContract: new MultichainContract(
+      account,
+      process.env.NEAR_MULTICHAIN_CONTRACT!
+    ),
+    derivationPath: "ethereum,1",
   });
 }
 

--- a/examples/sign-message.ts
+++ b/examples/sign-message.ts
@@ -5,7 +5,7 @@ dotenv.config();
 const run = async (): Promise<void> => {
   const evm = await setupNearEthAdapter();
   const message = "Hello World";
-  console.log(`Signing "${message}" with ${evm.ethPublicKey()}`);
+  console.log(`Signing "${message}" with ${evm.address}`);
 
   const signature = await evm.signMessage(message);
   console.log("Got Validated Signature", signature);

--- a/examples/weth/unwrap.ts
+++ b/examples/weth/unwrap.ts
@@ -1,6 +1,6 @@
 import wethABI from "../abis/WETH.json";
 import { encodeFunctionData, parseEther } from "viem";
-import { setupNearEthAdapter } from "../setup";
+import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "../setup";
 
 const run = async (): Promise<void> => {
   const neareth = await setupNearEthAdapter();
@@ -15,6 +15,7 @@ const run = async (): Promise<void> => {
       functionName: "withdraw",
       args: [parseEther(withdrawAmount.toString())],
     }),
+    chainId: SEPOLIA_CHAIN_ID,
   });
 };
 

--- a/examples/weth/wrap.ts
+++ b/examples/weth/wrap.ts
@@ -1,5 +1,5 @@
 import { parseEther } from "viem";
-import { setupNearEthAdapter } from "../setup";
+import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "../setup";
 
 const run = async (): Promise<void> => {
   const neareth = await setupNearEthAdapter();
@@ -11,6 +11,7 @@ const run = async (): Promise<void> => {
     to: sepoliaWETH,
     value: ethAmount,
     data: deposit,
+    chainId: SEPOLIA_CHAIN_ID,
   });
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,3 +2,4 @@ export * from "./chains/ethereum";
 export * from "./mpcContract";
 export * from "./chains/near";
 export * from "./types";
+export * from "./network";

--- a/src/network.ts
+++ b/src/network.ts
@@ -1,0 +1,84 @@
+import { Chain, createPublicClient, http, PublicClient } from "viem";
+import { sepolia, mainnet, gnosis, holesky } from "viem/chains";
+
+// All supported networks
+const SUPPORTED_NETWORKS = createNetworkMap([
+  mainnet,
+  gnosis,
+  sepolia,
+  holesky,
+]);
+
+interface NetworkFields {
+  name: string;
+  rpcUrl: string;
+  chainId: number;
+  scanUrl: string;
+  gasStationUrl: string;
+}
+/**
+ * Leveraging Network Data provided from through viem
+ * This class makes all relevant network fields accessible dynamically by chain ID.
+ */
+export class Network implements NetworkFields {
+  name: string;
+  rpcUrl: string;
+  chainId: number;
+  scanUrl: string;
+  gasStationUrl: string;
+  client: PublicClient;
+
+  constructor({
+    name,
+    rpcUrl,
+    chainId,
+    scanUrl,
+    gasStationUrl,
+  }: NetworkFields) {
+    const network = SUPPORTED_NETWORKS[chainId];
+
+    this.name = name;
+    this.rpcUrl = rpcUrl;
+    this.chainId = chainId;
+    this.scanUrl = scanUrl;
+    this.gasStationUrl = gasStationUrl;
+    this.client = createPublicClient({
+      transport: http(network.rpcUrl),
+    });
+  }
+
+  /// Returns Network by ChainId
+  static fromChainId(chainId: number): Network {
+    const networkFields = SUPPORTED_NETWORKS[chainId];
+    return new Network(networkFields);
+  }
+}
+
+type NetworkMap = { [key: number]: NetworkFields };
+
+/**
+ * This function is currently limited to networks supported by:
+ * https://status.beaconcha.in/
+ */
+function gasStationUrl(network: Chain): string {
+  if (network.id === 1) {
+    return "https://beaconcha.in/api/v1/execution/gasnow";
+  }
+  return `https://${network.name.toLowerCase()}.beaconcha.in/api/v1/execution/gasnow`;
+}
+
+/// Dynamically generate network map accessible by chainId.
+function createNetworkMap(supportedNetworks: Chain[]): NetworkMap {
+  const networkMap: NetworkMap = {};
+  supportedNetworks.forEach((network) => {
+    networkMap[network.id] = {
+      name: network.name,
+      rpcUrl: network.rpcUrls.default.http[0],
+      chainId: network.id,
+      scanUrl: network.blockExplorers?.default.url || "",
+      gasStationUrl: gasStationUrl(network),
+    };
+  });
+
+  return networkMap;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,41 @@ import { MultichainContract } from "./mpcContract";
 import { FunctionCallAction } from "@near-wallet-selector/core";
 import BN from "bn.js";
 import { Hex } from "viem";
+import { sepolia, mainnet, gnosis } from "viem/chains";
+
+interface Network {
+  name: string;
+  rpcUrl: string;
+  chainId: number;
+  scanUrl: string;
+  gasStationUrl: string;
+}
+
+type NetworkMap = { [key: number]: Network };
+
+export const NETWORK_MAP: NetworkMap = {
+  [mainnet.id]: {
+    name: mainnet.name,
+    rpcUrl: mainnet.rpcUrls.default.http[0],
+    chainId: mainnet.id,
+    scanUrl: mainnet.blockExplorers.default.url,
+    gasStationUrl: "https://mainnet.beaconcha.in/api/v1/execution/gasnow",
+  },
+  [gnosis.id]: {
+    name: gnosis.name,
+    rpcUrl: gnosis.rpcUrls.default.http[0],
+    chainId: gnosis.id,
+    scanUrl: gnosis.blockExplorers.default.url,
+    gasStationUrl: "https://gnosis.beaconcha.in/api/v1/execution/gasnow",
+  },
+  [sepolia.id]: {
+    name: sepolia.name,
+    rpcUrl: sepolia.rpcUrls.default.http[0],
+    chainId: sepolia.id,
+    scanUrl: sepolia.blockExplorers.default.url,
+    gasStationUrl: "https://sepolia.beaconcha.in/api/v1/execution/gasnow",
+  },
+};
 
 export interface BaseTx {
   /// Recipient of the transaction
@@ -10,25 +45,13 @@ export interface BaseTx {
   value?: bigint;
   /// Call Data of the transaction
   data?: `0x${string}`;
+  /// integer ID of the network for the transaction.
+  chainId: number;
+  /// Specified transaction nonce
+  nonce?: number;
 }
 
 export interface NearEthAdapterParams {
-  /// Near configuration.
-  near: NearParams;
-  /// EVM configuration.
-  evm: EvmParams;
-}
-
-export interface EvmParams {
-  /// The URL of the Ethereum JSON RPC provider.
-  providerUrl: string;
-  /// The base URL of the blockchain explorer.
-  scanUrl: string;
-  /// The base URL of the blockchain gas station.
-  gasStationUrl: string;
-}
-
-export interface NearParams {
   /// An instance of the NearMPC contract connected to the associated near account.
   mpcContract: MultichainContract;
   /// path used to generate ETH account from Near account (e.g. "ethereum,1")

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,41 +2,6 @@ import { MultichainContract } from "./mpcContract";
 import { FunctionCallAction } from "@near-wallet-selector/core";
 import BN from "bn.js";
 import { Hex } from "viem";
-import { sepolia, mainnet, gnosis } from "viem/chains";
-
-interface Network {
-  name: string;
-  rpcUrl: string;
-  chainId: number;
-  scanUrl: string;
-  gasStationUrl: string;
-}
-
-type NetworkMap = { [key: number]: Network };
-
-export const NETWORK_MAP: NetworkMap = {
-  [mainnet.id]: {
-    name: mainnet.name,
-    rpcUrl: mainnet.rpcUrls.default.http[0],
-    chainId: mainnet.id,
-    scanUrl: mainnet.blockExplorers.default.url,
-    gasStationUrl: "https://mainnet.beaconcha.in/api/v1/execution/gasnow",
-  },
-  [gnosis.id]: {
-    name: gnosis.name,
-    rpcUrl: gnosis.rpcUrls.default.http[0],
-    chainId: gnosis.id,
-    scanUrl: gnosis.blockExplorers.default.url,
-    gasStationUrl: "https://gnosis.beaconcha.in/api/v1/execution/gasnow",
-  },
-  [sepolia.id]: {
-    name: sepolia.name,
-    rpcUrl: sepolia.rpcUrls.default.http[0],
-    chainId: sepolia.id,
-    scanUrl: sepolia.blockExplorers.default.url,
-    gasStationUrl: "https://sepolia.beaconcha.in/api/v1/execution/gasnow",
-  },
-};
 
 export interface BaseTx {
   /// Recipient of the transaction

--- a/src/utils/gasPrice.ts
+++ b/src/utils/gasPrice.ts
@@ -14,7 +14,6 @@ interface GasPriceResponse {
 }
 
 export async function queryGasPrice(gasStationUrl: string): Promise<GasPrices> {
-  console.log("Querying gas station:", gasStationUrl);
   const res = await fetch(gasStationUrl);
   const gasPrices = (await res.json()) as GasPriceResponse;
   const maxPriorityFeePerGas = BigInt(getFirstNonZeroGasPrice(gasPrices)!);

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -48,7 +48,7 @@ describe("End To End", () => {
       adapter.signAndSendTransaction({
         to,
         value: senderBalance + ONE_WEI,
-        chainId: SEPOLIA_CHAIN_ID,
+        chainId,
       })
     ).rejects.toThrow();
   });

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -6,6 +6,7 @@ describe("End To End", () => {
   let adapter: NearEthAdapter;
   const to = "0xdeADBeeF0000000000000000000000000b00B1e5";
   const ONE_WEI = 1n;
+  const chainId = SEPOLIA_CHAIN_ID;
 
   beforeAll(async () => {
     adapter = await setupNearEthAdapter();
@@ -21,7 +22,7 @@ describe("End To End", () => {
         // Sending 1 WEI to self (so we never run out of funds)
         to: adapter.address,
         value: ONE_WEI,
-        chainId: SEPOLIA_CHAIN_ID,
+        chainId,
       })
     ).resolves.not.toThrow();
   });
@@ -39,7 +40,7 @@ describe("End To End", () => {
   });
 
   it("Fails to sign and send", async () => {
-    const network = Network.fromChainId(SEPOLIA_CHAIN_ID);
+    const network = Network.fromChainId(chainId);
     const senderBalance = await getBalance(network.client, {
       address: adapter.address,
     });

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -1,6 +1,5 @@
-import { createPublicClient, http } from "viem";
 import { SEPOLIA_CHAIN_ID, setupNearEthAdapter } from "../examples/setup";
-import { NETWORK_MAP, NearEthAdapter } from "../src";
+import { NearEthAdapter, Network } from "../src";
 import { getBalance } from "viem/actions";
 
 describe("End To End", () => {
@@ -19,19 +18,29 @@ describe("End To End", () => {
   it("signAndSendTransaction", async () => {
     await expect(
       adapter.signAndSendTransaction({
-        to,
+        // Sending 1 WEI to self (so we never run out of funds)
+        to: adapter.address,
         value: ONE_WEI,
         chainId: SEPOLIA_CHAIN_ID,
       })
     ).resolves.not.toThrow();
   });
 
+  it("signAndSendTransaction - Gnosis Chain", async () => {
+    await expect(
+      adapter.signAndSendTransaction({
+        // Sending 1 WEI to self (so we never run out of funds)
+        to: adapter.address,
+        value: ONE_WEI,
+        // Gnosis Chain!
+        chainId: 100,
+      })
+    ).resolves.not.toThrow();
+  });
+
   it("Fails to sign and send", async () => {
-    const network = NETWORK_MAP[SEPOLIA_CHAIN_ID];
-    const client = createPublicClient({
-      transport: http(network.rpcUrl),
-    });
-    const senderBalance = await getBalance(client, {
+    const network = Network.fromChainId(SEPOLIA_CHAIN_ID);
+    const senderBalance = await getBalance(network.client, {
       address: adapter.address,
     });
     await expect(

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -26,7 +26,7 @@ describe("End To End", () => {
     ).resolves.not.toThrow();
   });
 
-  it("signAndSendTransaction - Gnosis Chain", async () => {
+  it.skip("signAndSendTransaction - Gnosis Chain", async () => {
     await expect(
       adapter.signAndSendTransaction({
         // Sending 1 WEI to self (so we never run out of funds)


### PR DESCRIPTION
Making the Adapter Chain agnostic. The transaction sender now must include chainId in the BaseTx (offline signatures are not affected by this). We can construct all the necessary EVM client, gas station and scan URL by Chain ID. So all of these env vars are no longer necessary either.

Added a skipped test for Gnosis Chain (demonstrating the chain agnostic compatibility). 
