### PR TITLE
Gas Relayer Contracts

### DIFF
--- a/src/chains/ethereum.ts
+++ b/src/chains/ethereum.ts
@@ -22,7 +22,7 @@ import {
   TxPayload,
   TransactionWithSignature,
 } from "../types";
-import { MultichainContract } from "../mpcContract";
+import { MultichainContract } from "../contracts/mpc";
 import BN from "bn.js";
 import { queryGasPrice } from "../utils/gasPrice";
 import { buildTxPayload, addSignature } from "../utils/transaction";

--- a/src/chains/near.ts
+++ b/src/chains/near.ts
@@ -3,7 +3,7 @@ import { keyStores, KeyPair, connect, Account } from "near-api-js";
 import { Wallet } from "@near-wallet-selector/core";
 
 export const TGAS = new BN(1000000000000);
-export const NO_DEPOSIT = "0";
+export const NO_DEPOSIT = new BN("0");
 
 export interface NearConfig {
   networkId: string;

--- a/src/contracts/gas_station.ts
+++ b/src/contracts/gas_station.ts
@@ -1,0 +1,125 @@
+import { Contract, Account } from "near-api-js";
+import { NO_DEPOSIT, TGAS, nearAccountFromEnv } from "../chains/near";
+import { ChangeMethodArgs } from "../types";
+import BN from "bn.js";
+
+interface GetPaymasterArgs {
+  chain_id: string;
+}
+
+interface PaymasterConfiguration {
+  nonce: number;
+  token_id: string;
+  foreign_address: string;
+  minimum_available_balance: bigint;
+}
+
+interface SetPaymasterNonceArgs {
+  chain_id: string;
+  token_id: string;
+  nonce: number;
+}
+
+interface CreateTxArgs {
+  transaction_rlp_hex: string;
+  use_paymaster: boolean;
+  token_id: string;
+}
+
+interface SignNextArgs {
+  id: string;
+}
+
+interface TransactionSequenceCreation {
+  id: bigint;
+  pending_signature_count: number;
+}
+
+interface GasStationInterface extends Contract {
+  // TODO - determine return types...
+  get_paymasters: (
+    args: ChangeMethodArgs<GetPaymasterArgs>
+  ) => Promise<PaymasterConfiguration[]>;
+  set_paymaster_nonce: (
+    args: ChangeMethodArgs<SetPaymasterNonceArgs>
+  ) => Promise<void>;
+  create_transaction: (
+    args: ChangeMethodArgs<CreateTxArgs>
+  ) => Promise<TransactionSequenceCreation>;
+  /// This returns some deep nested Promise Type...
+  sign_next: (args: ChangeMethodArgs<SignNextArgs>) => Promise<void>;
+}
+
+/**
+ * High-level interface for the Near MPC-Recovery Contract
+ * located in: https://github.com/near/mpc-recovery
+ */
+export class GasStationContract {
+  contract: GasStationInterface;
+
+  constructor(account: Account, contractId: string) {
+    this.contract = new Contract(account, contractId, {
+      changeMethods: [
+        "get_paymasters",
+        "set_paymaster_nonce",
+        "create_transaction",
+        "sign_next",
+      ],
+      viewMethods: [],
+      useLocalViewExecution: false,
+    }) as GasStationInterface;
+  }
+
+  static async fromEnv(): Promise<GasStationContract> {
+    const account = await nearAccountFromEnv();
+    return new GasStationContract(
+      account,
+      process.env.NEAR_MULTICHAIN_CONTRACT!
+    );
+  }
+
+  async get_paymasters(
+    args: GetPaymasterArgs,
+    gas?: BN
+  ): Promise<PaymasterConfiguration[]> {
+    const paymasters = await this.contract.get_paymasters({
+      args,
+      gas: gas || TGAS.muln(100),
+      attachedDeposit: NO_DEPOSIT,
+    });
+    return paymasters;
+  }
+
+  async set_paymaster_nonce(
+    args: SetPaymasterNonceArgs,
+    gas?: BN
+  ): Promise<void> {
+    this.contract.set_paymaster_nonce({
+      args,
+      gas: gas || TGAS.muln(100),
+      attachedDeposit: NO_DEPOSIT,
+    });
+  }
+
+  async create_transaction(
+    args: CreateTxArgs,
+    attachedDeposit: BN,
+    gas?: BN
+  ): Promise<TransactionSequenceCreation> {
+    const sequence = await this.contract.create_transaction({
+      args,
+      gas: gas || TGAS.muln(100),
+      attachedDeposit,
+    });
+    return sequence;
+  }
+
+  async sign_next(args: SignNextArgs, gas?: BN): Promise<void> {
+    // TODO - determine return type.
+    await this.contract.sign_next({
+      args,
+      gas: gas || TGAS.muln(100),
+      attachedDeposit: NO_DEPOSIT,
+    });
+  }
+}

--- a/src/contracts/mpc.ts
+++ b/src/contracts/mpc.ts
@@ -4,17 +4,17 @@ import {
   deriveChildPublicKey,
   najPublicKeyStrToUncompressedHexPoint,
   uncompressedHexPointToEvmAddress,
-} from "./utils/kdf";
-import { NO_DEPOSIT, nearAccountFromEnv, TGAS } from "./chains/near";
+} from "../utils/kdf";
+import { NO_DEPOSIT, nearAccountFromEnv, TGAS } from "../chains/near";
 import BN from "bn.js";
 import {
   ChangeMethodArgs,
   MPCSignature,
   NearContractFunctionPayload,
   SignArgs,
-} from "./types";
+} from "../types";
 
-interface MultichainContractInterface extends Contract {
+interface MPCInterface extends Contract {
   // Define the signature for the `public_key` view method
   public_key: () => Promise<string>;
 
@@ -27,14 +27,14 @@ interface MultichainContractInterface extends Contract {
  * located in: https://github.com/near/mpc-recovery
  */
 export class MultichainContract {
-  contract: MultichainContractInterface;
+  contract: MPCInterface;
 
   constructor(account: Account, contractId: string) {
     this.contract = new Contract(account, contractId, {
       changeMethods: ["sign"],
       viewMethods: ["public_key"],
       useLocalViewExecution: false,
-    }) as MultichainContractInterface;
+    }) as MPCInterface;
   }
 
   static async fromEnv(): Promise<MultichainContract> {
@@ -65,7 +65,7 @@ export class MultichainContract {
       args: signArgs,
       // Default of 200 TGAS
       gas: gas || TGAS.muln(200),
-      attachedDeposit: new BN(NO_DEPOSIT),
+      attachedDeposit: NO_DEPOSIT,
     });
     return { big_r, big_s };
   };
@@ -84,7 +84,7 @@ export class MultichainContract {
             methodName: "sign",
             args: signArgs,
             gas: (gas || TGAS.muln(200)).toString(),
-            deposit: NO_DEPOSIT,
+            deposit: NO_DEPOSIT.toString(),
           },
         },
       ],

--- a/src/contracts/nft_key.ts
+++ b/src/contracts/nft_key.ts
@@ -1,0 +1,62 @@
+import { Contract, Account } from "near-api-js";
+import { NO_DEPOSIT, TGAS, nearAccountFromEnv } from "../chains/near";
+import { ChangeMethodArgs } from "../types";
+import BN from "bn.js";
+
+interface CktApproveArgs {
+  token_id: bigint;
+  account_id: string;
+  msg: string;
+}
+
+interface NftKeyInterface extends Contract {
+  // TODO - determine return types...
+  storage_deposit: (args: ChangeMethodArgs<object>) => Promise<void>;
+  mint: (args: ChangeMethodArgs<object>) => Promise<void>;
+  ckt_approve: (args: ChangeMethodArgs<CktApproveArgs>) => Promise<void>;
+}
+
+/**
+ * High-level interface for the Near MPC-Recovery Contract
+ * located in: https://github.com/near/mpc-recovery
+ */
+export class NftKeyContract {
+  contract: NftKeyInterface;
+
+  constructor(account: Account, contractId: string) {
+    this.contract = new Contract(account, contractId, {
+      changeMethods: ["storage_deposit", "mint", "ckt_approve"],
+      viewMethods: [],
+      useLocalViewExecution: false,
+    }) as NftKeyInterface;
+  }
+
+  static async fromEnv(): Promise<NftKeyContract> {
+    const account = await nearAccountFromEnv();
+    return new NftKeyContract(account, process.env.NEAR_MULTICHAIN_CONTRACT!);
+  }
+
+  async storage_deposit(attachedDeposit: bigint, gas?: BN): Promise<void> {
+    await this.contract.storage_deposit({
+      args: {},
+      gas: gas || TGAS.muln(100),
+      attachedDeposit: new BN(attachedDeposit.toString()),
+    });
+  }
+
+  async mint(gas?: BN): Promise<void> {
+    await this.contract.mint({
+      args: {},
+      gas: gas || TGAS.muln(100),
+      attachedDeposit: NO_DEPOSIT,
+    });
+  }
+
+  async ckt_approve(args: CktApproveArgs, gas?: BN): Promise<void> {
+    await this.contract.mint({
+      args,
+      gas: gas || TGAS.muln(100),
+      attachedDeposit: NO_DEPOSIT,
+    });
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export * from "./chains/ethereum";
-export * from "./mpcContract";
+export * from "./contracts/mpc";
 export * from "./chains/near";
 export * from "./types";
 export * from "./network";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import { MultichainContract } from "./mpcContract";
+import { MultichainContract } from "./contracts/mpc";
 import { FunctionCallAction } from "@near-wallet-selector/core";
 import BN from "bn.js";
 import { Hex } from "viem";

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -13,7 +13,7 @@ describe("End To End", () => {
   });
 
   afterAll(async () => {
-    clearTimeout();
+    clearTimeout(undefined);
   });
 
   it("signAndSendTransaction", async () => {


### PR DESCRIPTION
Providing contract interface for the methods required in [this tutorial](https://docs.near.org/build/chain-abstraction/multichain-gas-relayer/relayer-gas-example). I would have gone with the full ABI, but all the existing tooling seems to be failing.

<details><summary>Example Transaction Sequence</summary>

```
near contract call-function as-transaction nft.kagi.testnet storage_deposit json-args {} prepaid-gas '100.0 Tgas' attached-deposit '1 NEAR'

near contract call-function as-transaction nft.kagi.testnet mint json-args {} prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR'

near contract call-function as-transaction nft.kagi.testnet ckt_approve json-args '{"token_id":"118","account_id":"canhazgas.testnet","msg":""}' prepaid-gas '100.0 Tgas' attached-deposit '0 NEAR'


near contract call-function as-transaction canhazgas.testnet get_paymasters json-args '{"chain_id": "97"}' prepaid-gas '100.000 TeraGas' attached-deposit '0 NEAR' sign-as ethdenver2024.testnet network-config testnet sign-with-keychain send

near contract call-function as-transaction canhazgas.testnet set_paymaster_nonce json-args '{"chain_id": "97","token_id": "1", "nonce": 0}' prepaid-gas '100.000 TeraGas' attached-deposit '0 NEAR' sign-as ethdenver2024.testnet network-config testnet sign-with-keychain send

near contract call-function as-transaction canhazgas.testnet create_transaction json-args '{"transaction_rlp_hex":"ee6180847735940085174876e800825208947f01d9b227593e033bf8d6fc86e634d27aa85568865af3107a400080c0","use_paymaster":true, "token_id": "118"}' prepaid-gas '100.000 TeraGas' attached-deposit '0.5 NEAR' sign-as ethdenver2024.testnet network-config testnet sign-with-keychain send



near contract call-function as-transaction canhazgas.testnet sign_next json-args '{"id":"28"}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as ethdenver2024.testnet network-config testnet sign-with-keychain send
```
</details>


<details><summary>Result of two calls to sign_next </summary>

```
➜  near-ca git:(remove-BN) ✗ near contract call-function as-transaction canhazgas.testnet sign_next json-args '{"id":"30"}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as ethdenver2024.testnet network-config testnet sign-with-keychain send

Unsigned transaction:

signer_id:    ethdenver2024.testnet
receiver_id:  canhazgas.testnet
actions:
   -- function call:      
                   method name:  sign_next
                   args:         {
                                   "id": "30"
                                 }
                   gas:          300.0 Tgas
                   deposit:      0 NEAR

Warning: no access keys found in keychain, trying legacy keychain

Your transaction was signed successfully.
Public key: ed25519:6dgg56VuH8j52gR6cVnXndLe3XibUZ95tn1gppHz2iML
Signature: ed25519:md3WV443u3CufJunDjnHUdunTo2Mm9utfPheuwQ4vz3CNdpa4jjBru93PyKcYaSMCPw1hEnXcU9eiMnFZtqWzjT
▹▹▸▹▹ Sending transaction ...                                                                                   --- Logs ---------------------------
Logs [canhazgas.testnet]:   No logs
Logs [nft.kagi.testnet]:   No logs
Logs [multichain-testnet-2.testnet]:
  sign: signer=ethdenver2024.testnet, payload=[100, 225, 156, 29, 227, 78, 149, 169, 87, 174, 88, 219, 199, 219, 195, 11, 69, 75, 228, 161, 140, 237, 217, 128, 116, 205, 69, 218, 65, 239, 244, 19], path="1,", key_version=0
  [176,212,57,165,17,245,140,218,107,17,118,135,192,47,79,162,211,166,34,199,106,126,225,238,77,94,162,121,222,127,69,45]
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=0)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=1)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=2)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=3)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=4)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=5)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature ready: ("02C8145A8A7AD2517F7BF590D533ECA3A3ABB98279315A9E549A16B9569B5DF862", "438DD8C86FD18CCBBCBFF6D941D238F0DDFE22A45E095597821895FBC7EE5FBC"), depth: 6
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [nft.kagi.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [canhazgas.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
--- Result -------------------------
"0x02f8726101847735940085174876e800825208940c0a71335cc50b821570f6f8b302b248d0e56ed4870eebe0b40e800080c080a0c8145a8a7ad2517f7bf590d533eca3a3abb98279315a9e549a16b9569b5df862a0438dd8c86fd18ccbbcbff6d941d238f0ddfe22a45e095597821895fbc7ee5fbc"
------------------------------------

The "sign_next" call to <canhazgas.testnet> on behalf of <ethdenver2024.testnet> succeeded.
Transaction ID: DiHnK7vTEVJrC5mnfqhDK8UpoMQGCPeCZhzfFTn9bcR6
To see the transaction in the transaction explorer, please open this url in your browser:
https://explorer.testnet.near.org/transactions/DiHnK7vTEVJrC5mnfqhDK8UpoMQGCPeCZhzfFTn9bcR6




Here is your console command if you need to script it or re-run:
    near contract call-function as-transaction canhazgas.testnet sign_next json-args '{"id":"30"}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as ethdenver2024.testnet network-config testnet sign-with-keychain send

➜  near-ca git:(remove-BN) ✗ near contract call-function as-transaction canhazgas.testnet sign_next json-args '{"id":"30"}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as ethdenver2024.testnet network-config testnet sign-with-keychain send

Unsigned transaction:

signer_id:    ethdenver2024.testnet
receiver_id:  canhazgas.testnet
actions:
   -- function call:      
                   method name:  sign_next
                   args:         {
                                   "id": "30"
                                 }
                   gas:          300.0 Tgas
                   deposit:      0 NEAR

Warning: no access keys found in keychain, trying legacy keychain

Your transaction was signed successfully.
Public key: ed25519:6dgg56VuH8j52gR6cVnXndLe3XibUZ95tn1gppHz2iML
Signature: ed25519:4oJVbtsmdsmLV38G4Wiy9bXgTknH8MKQsppWvBcTaZLvEsiwSfGoSGa6hJ6ESAHrR6v4UXteAhcyzY9B961nWPZX
▹▹▹▸▹ Sending transaction ...                                                                                   --- Logs ---------------------------
Logs [canhazgas.testnet]:   No logs
Logs [nft.kagi.testnet]:   No logs
Logs [multichain-testnet-2.testnet]:
  sign: signer=ethdenver2024.testnet, payload=[49, 188, 252, 183, 195, 34, 38, 249, 198, 57, 159, 8, 26, 75, 85, 95, 211, 7, 213, 16, 141, 29, 175, 89, 250, 68, 80, 89, 64, 205, 146, 240], path="118,", key_version=0
  [183,179,6,105,120,159,190,245,243,139,214,0,233,34,128,62,189,94,180,62,33,7,202,105,138,78,231,137,35,17,248,141]
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=0)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=1)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=2)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=3)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=4)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=5)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=6)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature not ready yet (depth=7)
Logs [multichain-testnet-2.testnet]:
  sign_helper: signature ready: ("03B4A11B2ADD89EA5BCA5D86A81B88F48E3C84585599CF16A3995EED375FC2FF00", "59862D6A04038467689C5D94C9079906C0FD4B3D6132F8A8AD3B51199D170B25"), depth: 8
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [nft.kagi.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [ethdenver2024.testnet]:   No logs
Logs [canhazgas.testnet]:
  EVENT_JSON:{"standard":"x-gas-station","version":"0.1.0","event":"transaction_sequence_signed","data":{"id":"30","foreign_chain_id":"97","created_by_account_id":"ethdenver2024.testnet","signed_transactions":["0x02f8726101847735940085174876e800825208940c0a71335cc50b821570f6f8b302b248d0e56ed4870eebe0b40e800080c080a0c8145a8a7ad2517f7bf590d533eca3a3abb98279315a9e549a16b9569b5df862a0438dd8c86fd18ccbbcbff6d941d238f0ddfe22a45e095597821895fbc7ee5fbc","0x02f8716180847735940085174876e800825208947f01d9b227593e033bf8d6fc86e634d27aa85568865af3107a400080c001a0b4a11b2add89ea5bca5d86a81b88f48e3c84585599cf16a3995eed375fc2ff00a059862d6a04038467689c5d94c9079906c0fd4b3d6132f8a8ad3b51199d170b25"]}}
Logs [ethdenver2024.testnet]:   No logs
--- Result -------------------------
"0x02f8716180847735940085174876e800825208947f01d9b227593e033bf8d6fc86e634d27aa85568865af3107a400080c001a0b4a11b2add89ea5bca5d86a81b88f48e3c84585599cf16a3995eed375fc2ff00a059862d6a04038467689c5d94c9079906c0fd4b3d6132f8a8ad3b51199d170b25"
------------------------------------

The "sign_next" call to <canhazgas.testnet> on behalf of <ethdenver2024.testnet> succeeded.
Transaction ID: 2Pqn8PsP6toVna8SzyNdEMvHdEkT8ywNY1S9UHhxNCk8
To see the transaction in the transaction explorer, please open this url in your browser:
https://explorer.testnet.near.org/transactions/2Pqn8PsP6toVna8SzyNdEMvHdEkT8ywNY1S9UHhxNCk8




Here is your console command if you need to script it or re-run:
    near contract call-function as-transaction canhazgas.testnet sign_next json-args '{"id":"30"}' prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as ethdenver2024.testnet network-config testnet sign-with-keychain send

```
</details>


<details> <summary>Result of eth_sendRawTransaction</summary>

```
➜  $ curl https://bsc-testnet.public.blastapi.io \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x02f8726101847735940085174876e800825208940c0a71335cc50b821570f6f8b302b248d0e56ed4870eebe0b40e800080c080a0c8145a8a7ad2517f7bf590d533eca3a3abb98279315a9e549a16b9569b5df862a0438dd8c86fd18ccbbcbff6d941d238f0ddfe22a45e095597821895fbc7ee5fbc"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x01a9f2820422e58fd1b1a50371f8c5a6c94e62866526ede9f8df44308f6956e0"}

➜  $ ✗ curl https://bsc-testnet.public.blastapi.io \
  -X POST \
  -H "Content-Type: application/json" \
  --data '{"jsonrpc":"2.0","method":"eth_sendRawTransaction","params":["0x02f8716180847735940085174876e800825208947f01d9b227593e033bf8d6fc86e634d27aa85568865af3107a400080c001a0b4a11b2add89ea5bca5d86a81b88f48e3c84585599cf16a3995eed375fc2ff00a059862d6a04038467689c5d94c9079906c0fd4b3d6132f8a8ad3b51199d170b25"],"id":1}'
{"jsonrpc":"2.0","id":1,"result":"0x82ce8c158e12d0e019eab49d4a312cacdb4228fd6fed6c902deaf109276a056e"}
```
</details>

Note that the first of the two rawTxs is not yet mined... was this supposed to be the paymaster funding? Its weird.


# Questions

- So many near transactions! Will this get bundled?
	3 to kagi.nft
	5 to canhazgas get_paymasters, set_nonce, create_tx, sign_next (2x)

- What is the intermediary transaction?
	never gets mined... 

- How to get ABIs?