### PR TITLE
Update Dependencies (easy)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "@near-wallet-selector/core": "^8.9.5",
     "elliptic": "^6.5.5",
     "near-api-js": "^3.0.3",
-    "viem": "^2.8.14"
+    "viem": "^2.10.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "eslint": "^8.57.0",
     "ethers": "^6.12.0",
     "jest": "^29.7.0",
-    "opensea-js": "^7.0.9",
+    "opensea-js": "^7.1.8",
     "prettier": "^3.2.5",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2907,10 +2907,10 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-opensea-js@^7.0.9:
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/opensea-js/-/opensea-js-7.1.7.tgz#23988f13dcb277d4ae6b851ae97377a99e091f31"
-  integrity sha512-uyfgfx9jAPTshy983yex6j63r1aTz54Bu0Bfu1Sf+JXVPRqcyNuQWPEH7zf/nJx4noEUnQQsZDE1mg8Bdn04+g==
+opensea-js@^7.1.8:
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/opensea-js/-/opensea-js-7.1.8.tgz#d43434d47a1bb5c3e643ece80cc9dc8f2118a152"
+  integrity sha512-DBlfMuBoNfMvVO7siQQE72wCdgQqG0qgJWi9H8CNkaBrU2IMl2kAjZE//cbqZyWEb9Kie/CEpbT6ICy0wjh4dg==
   dependencies:
     "@opensea/seaport-js" "^4.0.0"
     ethers "^6.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -984,13 +984,6 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/keccak@^3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/keccak/-/keccak-3.0.4.tgz#bd4052c5484c55adfd4edb321dce841d8ed4119e"
-  integrity sha512-hdnkmbie7tE0yXnQQvlIOqCyjEsoXDVEZ3ACqO+F305XgUOW4Z9ElWdogCXXRAW/khnZ7GxM0t/BGB5bORKt/g==
-  dependencies:
-    "@types/node" "*"
-
 "@types/node@*", "@types/node@^20.11.30":
   version "20.12.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.11.tgz#c4ef00d3507000d17690643278a60dc55a9dc9be"
@@ -3466,7 +3459,7 @@ v8-to-istanbul@^9.0.1:
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^2.0.0"
 
-viem@^2.8.14:
+viem@^2.10.2:
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/viem/-/viem-2.10.2.tgz#65c2ca82b64e6fb9ee84c02b95dcf2c270ffe651"
   integrity sha512-gcOL+XxA0UWDarli856OEgumaBz4df/qNMpgno4NTSSZtJSC1XixIb3gWjVBei6Vx085ivw/U9ZE8gdniIo7fA==


### PR DESCRIPTION
When running `yarn outdated` we got a list of 4 outdated dependencies. We were easily able to update `viem` and `opensea`. Remaining will come in separate PRs.

```sh
➜  near-ca git:(yarn-outdated) yarn outdated
yarn outdated v1.22.22
Package     Current Wanted Latest Package Type    URL                                           
eslint      8.57.0  8.57.0 9.2.0  devDependencies https://eslint.org                            
near-api-js 3.0.4   3.0.4  4.0.1  dependencies    https://github.com/near/near-api-js
```