### PR TITLE
Signature Recovery: Handle Inconsistent Near RPC Receipts

### DIFF
--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -40,11 +40,11 @@ export async function signatureFromTxHash(
     // Find the first non-empty value
     base64Sig = successValues.find((value) => value && value.trim().length > 0);
   }
-  try {
+  if (base64Sig) {
     const decodedValue = Buffer.from(base64Sig, "base64").toString("utf-8");
     const [big_r, big_s] = JSON.parse(decodedValue);
     return { big_r, big_s };
-  } catch (error: any) {
+  } else {
     throw new Error("No valid values found in the array.");
   }
 }

--- a/tests/unit/utils.signature.test.ts
+++ b/tests/unit/utils.signature.test.ts
@@ -14,6 +14,19 @@ describe("utility: get Signature", () => {
       big_s: "67986E234DEC5D51CF6AED452FE1C4544924218AC20B009F81BAAE53C02AFE76",
     });
   });
+
+  it("successful: alternative signatureFromTxHash", async () => {
+    const sig = await signatureFromTxHash(
+      url,
+      "EK4XUwyR29w6eaSfSSPb8he3y7nkTQSbYJVXgSx5vZ4T"
+    );
+    expect(sig).toEqual({
+      big_r:
+        "024598E193A9377B98A5B4621BA81FDEEA9DED3E3E7F41C073D0537BC2769C10FC",
+      big_s: "65D23B4EA333FFC5486FA295B7AEAB02EACA4E35E22B55108563A63199B96558",
+    });
+  });
+
   it("failed: signatureFromTxHash", async () => {
     await expect(signatureFromTxHash(url, failedHash)).rejects.toThrow(
       "No valid values found in the array."


### PR DESCRIPTION
Sometimes the return values are not in the place one would expect, this adds an alternative path to handle different scenarios when necessary (at least we don't error in plausible cases).

## Test Plan

Added new test that covers this route...