### PR TITLE
Installation with `npm` fails, add a section in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ npx ts-node examples/opensea.ts
 # You will be prompted to provide a collectionSlug
 ```
 
+Using `npm` could potentially cause peer dependency mismatches. If the installation fails, run `npm i --force` to continue.
+
 ## Installation
 
 To install NEAR-CA, run the following command:


### PR DESCRIPTION
Following the Local Testing instructions using `npm` instead of `yarn` doesn't work because of dependency mismatches.

This PR adds a paragraph for steps with a workaround.