### PR TITLE
Remove dotenv Constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,19 +80,28 @@ import dotenv from "dotenv";
 import {
   MultichainContract,
   NearEthAdapter,
-  nearAccountFromEnv,
+  nearAccountFromKeyPair,
 } from "near-ca";
+import { KeyPair } from "near-api-js";
 
 dotenv.config();
+const { NEAR_ACCOUNT_ID, NEAR_ACCOUNT_PRIVATE_KEY } = process.env;
 
-const account = await nearAccountFromEnv();
+const account = await nearAccountFromKeyPair({
+    accountId: NEAR_ACCOUNT_ID!,
+    keyPair: KeyPair.fromString(NEAR_ACCOUNT_PRIVATE_KEY!),
+    network: {
+      networkId: "testnet",
+      nodeUrl: "https://rpc.testnet.near.org",
+    },
+  });
 
 const adapter = await NearEthAdapter.fromConfig({
   mpcContract: new MultichainContract(
     account,
     process.env.NEAR_MULTICHAIN_CONTRACT!
   ),
-  derivationPath: "ethereum,1",
+  // derivationPath: "ethereum,1",
 });
 
 await adapter.signAndSendTransaction({

--- a/examples/setup.ts
+++ b/examples/setup.ts
@@ -1,18 +1,31 @@
 import dotenv from "dotenv";
-import { MultichainContract, NearEthAdapter, nearAccountFromEnv } from "../src";
+import {
+  MultichainContract,
+  NearEthAdapter,
+  nearAccountFromKeyPair,
+} from "../src";
+import { KeyPair } from "near-api-js";
 
 // This is Sepolia, but can be replaced with nearly any EVM network.
 export const SEPOLIA_CHAIN_ID = 11_155_111;
+const TESTNET_CONFIG = {
+  networkId: "testnet",
+  nodeUrl: "https://rpc.testnet.near.org",
+};
 
 export async function setupNearEthAdapter(): Promise<NearEthAdapter> {
   dotenv.config();
-  const account = await nearAccountFromEnv();
+  const account = await nearAccountFromKeyPair({
+    keyPair: KeyPair.fromString(process.env.NEAR_ACCOUNT_PRIVATE_KEY!),
+    accountId: process.env.NEAR_ACCOUNT_ID!,
+    network: TESTNET_CONFIG,
+  });
   return NearEthAdapter.fromConfig({
     mpcContract: new MultichainContract(
       account,
       process.env.NEAR_MULTICHAIN_CONTRACT!
     ),
-    derivationPath: "ethereum,1",
+    // derivationPath: "ethereum,1",
   });
 }
 

--- a/src/mpcContract.ts
+++ b/src/mpcContract.ts
@@ -5,12 +5,14 @@ import {
   najPublicKeyStrToUncompressedHexPoint,
   uncompressedHexPointToEvmAddress,
 } from "./utils/kdf";
-import { NO_DEPOSIT, nearAccountFromEnv, TGAS } from "./chains/near";
+import { NO_DEPOSIT, TGAS } from "./chains/near";
 import {
   MPCSignature,
   NearContractFunctionPayload,
   SignArgs,
 } from "./types/types";
+
+const DEFAULT_MPC_CONTRACT = "v2.multichain-mpc.testnet";
 
 /// Near Contract Type for change methods
 export interface ChangeMethodArgs<T> {
@@ -38,21 +40,14 @@ export class MultichainContract {
   contract: MultichainContractInterface;
   connectedAccount: Account;
 
-  constructor(account: Account, contractId: string) {
+  constructor(account: Account, contractId: string = DEFAULT_MPC_CONTRACT) {
     this.connectedAccount = account;
+
     this.contract = new Contract(account, contractId, {
       changeMethods: ["sign"],
       viewMethods: ["public_key"],
       useLocalViewExecution: false,
     }) as MultichainContractInterface;
-  }
-
-  static async fromEnv(): Promise<MultichainContract> {
-    const account = await nearAccountFromEnv();
-    return new MultichainContract(
-      account,
-      process.env.NEAR_MULTICHAIN_CONTRACT!
-    );
   }
 
   deriveEthAddress = async (derivationPath: string): Promise<Address> => {


### PR DESCRIPTION
Since this is a published package, users would be worried about their dependency reading their env files. Instead we force the user to construct their own instances of stuff.

This is a breaking change for anyone using this, but we will still publish under 0.1.* since its still so early and nobody even noticed yet we had a v0.1.0