### PR TITLE
NAJS: Fix Deprecation Warning

### DIFF
--- a/src/chains/near.ts
+++ b/src/chains/near.ts
@@ -1,4 +1,4 @@
-import { keyStores, KeyPair, connect, Account, Near } from "near-api-js";
+import { keyStores, KeyPair, connect, Account } from "near-api-js";
 
 export const TGAS = 1000000000000n;
 export const NO_DEPOSIT = "0";
@@ -6,11 +6,6 @@ export const NO_DEPOSIT = "0";
 export interface NearConfig {
   networkId: string;
   nodeUrl: string;
-}
-
-export interface NearAccount {
-  near: Near;
-  account: Account;
 }
 
 /**

--- a/src/chains/near.ts
+++ b/src/chains/near.ts
@@ -1,4 +1,4 @@
-import { keyStores, KeyPair, connect, Account } from "near-api-js";
+import { keyStores, KeyPair, connect, Account, Near } from "near-api-js";
 
 export const TGAS = 1000000000000n;
 export const NO_DEPOSIT = "0";
@@ -6,6 +6,11 @@ export const NO_DEPOSIT = "0";
 export interface NearConfig {
   networkId: string;
   nodeUrl: string;
+}
+
+export interface NearAccount {
+  near: Near;
+  account: Account;
 }
 
 /**
@@ -44,6 +49,5 @@ const createNearAccount = async (
     await keyStore.setKey(network.networkId, accountId, keyPair);
   }
   const near = await connect({ ...network, keyStore });
-  const account = await near.account(accountId);
-  return account;
+  return near.account(accountId);
 };

--- a/src/mpcContract.ts
+++ b/src/mpcContract.ts
@@ -22,6 +22,8 @@ export interface ChangeMethodArgs<T> {
   gas: string;
   /// Deposit (i.e. payable amount) to attach to transaction.
   attachedDeposit: string;
+  /// Account Signing the call
+  signerAccount: Account;
 }
 
 interface MultichainContractInterface extends Contract {
@@ -43,7 +45,7 @@ export class MultichainContract {
   constructor(account: Account, contractId: string = DEFAULT_MPC_CONTRACT) {
     this.connectedAccount = account;
 
-    this.contract = new Contract(account, contractId, {
+    this.contract = new Contract(account.connection, contractId, {
       changeMethods: ["sign"],
       viewMethods: ["public_key"],
       useLocalViewExecution: false,
@@ -68,6 +70,7 @@ export class MultichainContract {
   ): Promise<MPCSignature> => {
     const [big_r, big_s] = await this.contract.sign({
       args: signArgs,
+      signerAccount: this.connectedAccount,
       gas: gasOrDefault(gas),
       attachedDeposit: NO_DEPOSIT,
     });


### PR DESCRIPTION
Resolves the deprecation warning

```
new Contract(account, contractId, options) deprecated use `new Contract(connection, contractId, options)
```


### Test Plan 
Existing CI