### PR TITLE
Remove Delegate Signature Recovery

### DIFF
--- a/src/types/rpc.ts
+++ b/src/types/rpc.ts
@@ -1,8 +1,13 @@
 // Basic structure of the JSON-RPC response
-export interface JSONRPCResponse {
+export interface JSONRPCResponse<T> {
   jsonrpc: string;
-  result: Result;
-  id: string;
+  id: number | string | null;
+  result?: T;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
 }
 
 // Result contains various fields like final execution status, an array of receipts, etc.

--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -32,19 +32,7 @@ export async function signatureFromTxHash(
   });
 
   const jsonResponse = (await response.json()) as JSONRPCResponse;
-  let base64Sig = jsonResponse.result.status?.SuccessValue;
-  // TODO: Find an example when successValue isn't available and we need to enter this block.
-  if (base64Sig === "") {
-    // Extract receipts_outcome
-    const receiptsOutcome = jsonResponse.result.receipts_outcome;
-    // Map to get SuccessValue
-    const successValues = receiptsOutcome.map(
-      // eslint-disable-next-line
-      (outcome: any) => outcome.outcome.status.SuccessValue
-    );
-    // Find the first non-empty value
-    base64Sig = successValues.find((value) => value && value.trim().length > 0);
-  }
+  const base64Sig = jsonResponse.result.status?.SuccessValue;
   if (base64Sig) {
     const decodedValue = Buffer.from(base64Sig, "base64").toString("utf-8");
     const signature: MPCSignature = JSON.parse(decodedValue);

--- a/tests/unit/utils.signature.test.ts
+++ b/tests/unit/utils.signature.test.ts
@@ -20,7 +20,7 @@ describe("utility: get Signature", () => {
 
   it("failed: signatureFromTxHash", async () => {
     await expect(signatureFromTxHash(url, failedHash)).rejects.toThrow(
-      `No valid values found in transaction receipt ${failedHash}`
+      `No detectable signature found in transaction ${failedHash}`
     );
   });
 

--- a/tests/unit/utils.signature.test.ts
+++ b/tests/unit/utils.signature.test.ts
@@ -18,19 +18,6 @@ describe("utility: get Signature", () => {
     });
   });
 
-  // Still need a NEW example of this!
-  // it("successful: alternative signatureFromTxHash", async () => {
-  //   const sig = await signatureFromTxHash(
-  //     url,
-  //     "EK4XUwyR29w6eaSfSSPb8he3y7nkTQSbYJVXgSx5vZ4T"
-  //   );
-  //   expect(sig).toEqual({
-  //     big_r:
-  //       "024598E193A9377B98A5B4621BA81FDEEA9DED3E3E7F41C073D0537BC2769C10FC",
-  //     big_s: "65D23B4EA333FFC5486FA295B7AEAB02EACA4E35E22B55108563A63199B96558",
-  //   });
-  // });
-
   it("failed: signatureFromTxHash", async () => {
     await expect(signatureFromTxHash(url, failedHash)).rejects.toThrow(
       `No valid values found in transaction receipt ${failedHash}`

--- a/tests/unit/utils.signature.test.ts
+++ b/tests/unit/utils.signature.test.ts
@@ -18,9 +18,15 @@ describe("utility: get Signature", () => {
     });
   });
 
-  it("failed: signatureFromTxHash", async () => {
+  it("signatureFromTxHash fails with no signature", async () => {
     await expect(signatureFromTxHash(url, failedHash)).rejects.toThrow(
       `No detectable signature found in transaction ${failedHash}`
+    );
+  });
+
+  it("signatureFromTxHash fails with parse error", async () => {
+    await expect(signatureFromTxHash(url, "nonsense")).rejects.toThrow(
+      "JSON-RPC error: Parse error"
     );
   });
 


### PR DESCRIPTION
### **User description**
The only reason we had that special search in signature retrieval was for delegated actions through a relayer.
The MPC contract recently introduced a 1 yoctoNear deposit so I am guessing that this is no longer possible.

**Reference Transaction:**
https://testnet.nearblocks.io/txns/EK4XUwyR29w6eaSfSSPb8he3y7nkTQSbYJVXgSx5vZ4T?tab=execution

We can always bring this back if necessary.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Simplified the signature retrieval logic by removing the fallback mechanism that searched for `SuccessValue` in `receipts_outcome`.
- Updated the unit tests by removing the commented-out test case for the alternative signature retrieval.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signature.ts</strong><dd><code>Simplify signature retrieval logic by removing fallback mechanism</code></dd></summary>
<hr>

src/utils/signature.ts

<li>Removed the fallback mechanism for retrieving the signature from <br><code>receipts_outcome</code>.<br> <li> Simplified the retrieval of <code>SuccessValue</code> from the transaction result.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/86/files#diff-0dcd6c8a6f6ba88fa3b6994d7e4594fe15879dd55b386d9663abe17b02b0501a">+1/-13</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.signature.test.ts</strong><dd><code>Remove obsolete test case for alternative signature retrieval</code></dd></summary>
<hr>

tests/unit/utils.signature.test.ts

<li>Removed the commented-out test case for the alternative signature <br>retrieval.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/86/files#diff-d6587b10831e36ea2f2e8468588145cf4b32b302e0940ad5c01a85846fd6a175">+0/-13</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

