### PR TITLE
Fix Config & Rename Multichain Contract

### DIFF
--- a/src/chains/near.ts
+++ b/src/chains/near.ts
@@ -1,12 +1,28 @@
 import { keyStores, KeyPair, connect, Account } from "near-api-js";
+import { NearConfig } from "near-api-js/lib/near";
 
 export const TGAS = 1000000000000n;
 export const NO_DEPOSIT = "0";
 export const ONE_YOCTO = "1";
 
-export interface NearConfig {
-  networkId: string;
-  nodeUrl: string;
+type NetworkId = "mainnet" | "testnet";
+
+export function getNetworkId(accountId: string): NetworkId {
+  const accountExt = accountId.split(".").pop() || "";
+  if (!["near", "testnet"].includes(accountExt)) {
+    console.warn(
+      `Unusual or invalid network extracted from accountId ${accountId}`
+    );
+  }
+  // Consider anything that isn't testnet as mainnet.
+  return accountExt !== "testnet" ? "mainnet" : accountExt;
+}
+
+export function configFromNetworkId(networkId: NetworkId): NearConfig {
+  return {
+    networkId,
+    nodeUrl: `https://rpc.${networkId}.near.org`,
+  };
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,11 @@ import { Account, KeyPair } from "near-api-js";
 import { NearEthAdapter } from "./chains/ethereum";
 import { MultichainContract } from "./mpcContract";
 import { NearConfig } from "near-api-js/lib/near";
-import { createNearAccount } from "./chains/near";
+import {
+  configFromNetworkId,
+  createNearAccount,
+  getNetworkId,
+} from "./chains/near";
 
 export * from "./chains/ethereum";
 export * from "./chains/near";
@@ -20,24 +24,6 @@ interface SetupConfig {
   derivationPath?: string;
 }
 
-type NetworkId = "near" | "testnet";
-
-function getNetworkId(accountId: string): NetworkId {
-  const networkId = accountId.split(".").pop() || "";
-  if (!["near", "testnet"].includes(networkId)) {
-    throw new Error(`Invalid network extracted from accountId ${accountId}`);
-  }
-  return networkId as NetworkId;
-}
-
-export function configFromNetworkId(networkId: NetworkId): NearConfig {
-  const network = networkId === "near" ? "mainnet" : "testnet";
-  return {
-    networkId,
-    nodeUrl: `https://rpc.${network}.near.org`,
-  };
-}
-
 export async function setupAdapter(args: SetupConfig): Promise<NearEthAdapter> {
   const {
     accountId,
@@ -50,7 +36,7 @@ export async function setupAdapter(args: SetupConfig): Promise<NearEthAdapter> {
   const config = args.network ?? configFromNetworkId(accountNetwork);
   if (accountNetwork !== config.networkId) {
     throw new Error(
-      `The accountId ${accountId} does not match the networkId ${config.networkId}. Please ensure that your accountId is correct and corresponds to the intended network.`
+      `accountId ${accountId} doesn't match the networkId ${config.networkId}. Please ensure that your accountId is correct and corresponds to the intended network.`
     );
   }
 
@@ -59,6 +45,7 @@ export async function setupAdapter(args: SetupConfig): Promise<NearEthAdapter> {
     account = await createNearAccount(
       accountId,
       config,
+      // Without private key, MPC contract connection is read-only.
       privateKey ? KeyPair.fromString(privateKey) : undefined
     );
   } catch (error: unknown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { Account, KeyPair } from "near-api-js";
 import { NearEthAdapter } from "./chains/ethereum";
-import { MultichainContract } from "./mpcContract";
+import { MultichainContract as MpcContract } from "./mpcContract";
 import { NearConfig } from "near-api-js/lib/near";
 import {
   configFromNetworkId,
@@ -53,7 +53,7 @@ export async function setupAdapter(args: SetupConfig): Promise<NearEthAdapter> {
     throw error;
   }
   return NearEthAdapter.fromConfig({
-    mpcContract: new MultichainContract(account, mpcContractId),
+    mpcContract: new MpcContract(account, mpcContractId),
     derivationPath: derivationPath,
   });
 }

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -30,16 +30,15 @@ describe("index", () => {
   });
 
   it("setupAdapter fails", async () => {
+    const accountId = "your-account.testnet";
+    const networkId = "mainnet";
     const config = {
-      accountId: "your-account.testnet",
-      network: {
-        networkId: "near",
-        nodeUrl: "https://rpc.mainnet.near.org",
-      },
+      accountId,
+      network: configFromNetworkId(networkId),
       mpcContractId: "v1.signer-prod.testnet",
     };
     await expect(() => setupAdapter(config)).rejects.toThrow(
-      "The accountId your-account.testnet does not match the networkId near."
+      `accountId ${accountId} doesn't match the networkId ${networkId}. Please ensure that your accountId is correct and corresponds to the intended network.`
     );
   });
 

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -44,8 +44,8 @@ describe("index", () => {
   });
 
   it("configFromNetworkId", async () => {
-    expect(configFromNetworkId("near")).toStrictEqual({
-      networkId: "near",
+    expect(configFromNetworkId("mainnet")).toStrictEqual({
+      networkId: "mainnet",
       nodeUrl: "https://rpc.mainnet.near.org",
     });
 


### PR DESCRIPTION
### **User description**
- use mainnet as networkId instead of near
- use mainnet whenever accountId doesn't end in testnet.
- *Breaking Change* Rename MultichainContract as MpcContract


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Added `getNetworkId` function to determine network from accountId in `src/chains/near.ts`.
- Added `configFromNetworkId` function to generate NearConfig based on networkId in `src/chains/near.ts`.
- Renamed `MultichainContract` to `MpcContract` in `src/index.ts`.
- Updated `setupAdapter` function to use new network ID functions in `src/index.ts`.
- Simplified network ID extraction and configuration logic in `src/index.ts`.
- Updated tests in `tests/unit/index.test.ts` to reflect changes in network ID handling and configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>near.ts</strong><dd><code>Add network ID handling and configuration functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chains/near.ts

<li>Added <code>getNetworkId</code> function to determine network from accountId.<br> <li> Added <code>configFromNetworkId</code> function to generate NearConfig based on <br>networkId.<br> <li> Removed <code>NearConfig</code> interface definition.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/90/files#diff-1822d8d68a66add58ce94aa9704074f07d1d431307c4276373872a4529c11aa0">+19/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Rename contract and update network configuration logic</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/index.ts

<li>Renamed <code>MultichainContract</code> to <code>MpcContract</code>.<br> <li> Updated <code>setupAdapter</code> to use new network ID functions.<br> <li> Simplified network ID extraction and configuration logic.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/90/files#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80">+9/-22</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.test.ts</strong><dd><code>Update tests for network ID handling changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/index.test.ts

<li>Updated tests to reflect changes in network ID handling.<br> <li> Changed test cases to use "mainnet" instead of "near".<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/90/files#diff-110a6b6e861a5751dbc7f61aa97f83538c14caf3494b6303ab0e4fd2317190ca">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

