### PR TITLE
deduplicate Array.from(toBytes...) and more cosmetic improvements

### DIFF
--- a/src/chains/ethereum.ts
+++ b/src/chains/ethereum.ts
@@ -4,8 +4,6 @@ import {
   Hash,
   serializeTransaction,
   hashMessage,
-  toBytes,
-  isBytes,
   SignableMessage,
   serializeSignature,
   hashTypedData,
@@ -24,7 +22,12 @@ import {
   SignArgs,
 } from "../types";
 import { MpcContract } from "../mpcContract";
-import { buildTxPayload, addSignature, populateTx } from "../utils/transaction";
+import {
+  buildTxPayload,
+  addSignature,
+  populateTx,
+  toPayload,
+} from "../utils/transaction";
 import { Network } from "../network";
 import { Web3WalletTypes } from "@walletconnect/web3wallet";
 import { wcRouter } from "../wallet-connect/handlers";
@@ -90,16 +93,12 @@ export class NearEthAdapter {
     txData: BaseTx,
     nearGas?: bigint
   ): Promise<Hash> {
-    console.log("Creating Payload for sender:", this.address);
     const { transaction, signArgs } = await this.createTxPayload(txData);
-    console.log(
-      `Requesting signature from Near at ${this.mpcContract.accountId}`
-    );
+    console.log(`Requesting signature from ${this.mpcContract.accountId()}`);
     const signature = await this.mpcContract.requestSignature(
       signArgs,
       nearGas
     );
-    console.log("Raw signature received");
     return this.relayTransaction({ transaction, signature });
   }
 
@@ -119,7 +118,6 @@ export class NearEthAdapter {
     transaction: Hex;
     requestPayload: FunctionCallTransaction<{ request: SignArgs }>;
   }> {
-    console.log("Creating Payload for sender:", this.address);
     const { transaction, signArgs } = await this.createTxPayload(txData);
     return {
       transaction,
@@ -170,6 +168,9 @@ export class NearEthAdapter {
    * @returns Transaction and its bytes (the payload to be signed on Near).
    */
   async createTxPayload(tx: BaseTx): Promise<TxPayload> {
+    console.log(
+      `Creating payload for sender: ${this.nearAccountId()} <> ${this.address}`
+    );
     const transaction = await this.buildTransaction(tx);
     console.log("Built (unsigned) Transaction", transaction);
     const signArgs = {
@@ -234,11 +235,9 @@ export class NearEthAdapter {
    * @returns Two different potential signatures for the hash (one of which is valid).
    */
   async sign(msgHash: `0x${string}` | Uint8Array): Promise<Hex> {
-    const hashToSign = isBytes(msgHash) ? msgHash : toBytes(msgHash);
-
     const signature = await this.mpcContract.requestSignature({
       path: this.derivationPath,
-      payload: Array.from(hashToSign),
+      payload: toPayload(msgHash),
       key_version: 0,
     });
     return serializeSignature(signature);
@@ -253,12 +252,12 @@ export class NearEthAdapter {
       request: { method, params },
     } = request.params!;
     console.log(`Session Request of type ${method} for chainId ${chainId}`);
-    const { evmMessage, payload, signatureRecoveryData } = await wcRouter(
+    const { evmMessage, payload, recoveryData } = await wcRouter(
       method,
       chainId,
       params
     );
-    console.log("Parsed Request:", payload, signatureRecoveryData);
+    console.log("Parsed Request:", payload, recoveryData);
     return {
       nearPayload: this.mpcContract.encodeSignatureRequestTx({
         path: this.derivationPath,
@@ -266,7 +265,7 @@ export class NearEthAdapter {
         key_version: 0,
       }),
       evmMessage,
-      recoveryData: signatureRecoveryData,
+      recoveryData,
     };
   }
 }

--- a/src/utils/transaction.ts
+++ b/src/utils/transaction.ts
@@ -2,6 +2,7 @@ import {
   Hex,
   PublicClient,
   TransactionSerializable,
+  isBytes,
   keccak256,
   parseTransaction,
   serializeTransaction,
@@ -10,11 +11,12 @@ import {
 import { BaseTx, TransactionWithSignature } from "../types";
 import { Network } from "../network";
 
-export function toPayload(hexString: Hex): number[] {
-  if (hexString.slice(2).length !== 32 * 2) {
-    throw new Error(`Payload Hex must have 32 bytes: ${hexString}`);
+export function toPayload(msgHash: Hex | Uint8Array): number[] {
+  const bytes = isBytes(msgHash) ? msgHash : toBytes(msgHash);
+  if (bytes.length !== 32) {
+    throw new Error(`Payload must have 32 bytes: ${msgHash}`);
   }
-  return Array.from(toBytes(hexString));
+  return Array.from(bytes);
 }
 
 export function buildTxPayload(unsignedTxHash: `0x${string}`): number[] {

--- a/src/wallet-connect/handlers.ts
+++ b/src/wallet-connect/handlers.ts
@@ -41,7 +41,7 @@ export async function wcRouter(
 ): Promise<{
   evmMessage: TransactionSerializable | string;
   payload: number[];
-  signatureRecoveryData: RecoveryData;
+  recoveryData: RecoveryData;
 }> {
   switch (method) {
     case "eth_sign": {
@@ -49,7 +49,7 @@ export async function wcRouter(
       return {
         evmMessage: fromHex(messageHash, "string"),
         payload: toPayload(hashMessage({ raw: messageHash })),
-        signatureRecoveryData: {
+        recoveryData: {
           type: method,
           data: {
             address: sender,
@@ -63,7 +63,7 @@ export async function wcRouter(
       return {
         evmMessage: fromHex(messageHash, "string"),
         payload: toPayload(hashMessage({ raw: messageHash })),
-        signatureRecoveryData: {
+        recoveryData: {
           type: method,
           data: {
             address: sender,
@@ -87,7 +87,7 @@ export async function wcRouter(
       return {
         payload: toPayload(keccak256(serializeTransaction(transaction))),
         evmMessage: transaction,
-        signatureRecoveryData: {
+        recoveryData: {
           type: "eth_sendTransaction",
           data: serializeTransaction(transaction),
         },
@@ -100,7 +100,7 @@ export async function wcRouter(
       return {
         evmMessage: dataString,
         payload: toPayload(hashTypedData(typedData)),
-        signatureRecoveryData: {
+        recoveryData: {
           type: "eth_signTypedData",
           data: {
             address: sender,

--- a/tests/unit/utils.transaction.test.ts
+++ b/tests/unit/utils.transaction.test.ts
@@ -22,7 +22,7 @@ describe("Transaction Builder Functions", () => {
     const txHash =
       "0x02e783aa36a7808309e8bb84773f7cbb8094deadbeef0000000000000000000000000b00b1e50180c00";
     expect(() => toPayload(txHash)).toThrow(
-      `Payload Hex must have 32 bytes: ${txHash}`
+      `Payload must have 32 bytes: ${txHash}`
     );
   });
 


### PR DESCRIPTION
### **User description**
Closes #82

We use `toPayload` on Adapter.sign so that we are only constructing payloads in one singular place.

Also found a few other places (naming conventions) that could be cleanedup/improved.


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Refactored `toPayload` function to handle both `Hex` and `Uint8Array` types, improving payload validation.
- Removed redundant imports and deduplicated payload creation logic in `NearEthAdapter`.
- Enhanced logging messages for better clarity and debugging.
- Standardized variable names for consistency across the codebase.
- Updated unit tests to reflect changes in error messages.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ethereum.ts</strong><dd><code>Refactor and improve payload handling and logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chains/ethereum.ts

<li>Removed redundant <code>toBytes</code> and <code>isBytes</code> imports.<br> <li> Added <code>toPayload</code> import and used it to deduplicate payload creation.<br> <li> Improved logging messages for better clarity.<br> <li> Simplified variable names and removed unnecessary console logs.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/92/files#diff-9cae2980092ecb69c0204c332224ce902083c2eea7ac9a084f296c16d4714510">+14/-15</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>transaction.ts</strong><dd><code>Enhance `toPayload` function for better validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utils/transaction.ts

<li>Modified <code>toPayload</code> function to handle both <code>Hex</code> and <code>Uint8Array</code>.<br> <li> Improved error message for payload validation.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/92/files#diff-70ff3efd3e0f849598385983d802d9dda008aa869698ea82507cfc54e653bc17">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>handlers.ts</strong><dd><code>Standardize recovery data naming and payload creation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/wallet-connect/handlers.ts

<li>Renamed <code>signatureRecoveryData</code> to <code>recoveryData</code> for consistency.<br> <li> Updated payload creation to use the enhanced <code>toPayload</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/92/files#diff-2ed558c985bc318440bbfca058163eb4d804cac3d6068b56e0093bef599d6022">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.transaction.test.ts</strong><dd><code>Update test for `toPayload` error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/utils.transaction.test.ts

<li>Updated test case to reflect the improved error message in <code>toPayload</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/92/files#diff-b2e21cc8dcc33d022a0330c01022e4d45071ec0cfcc95049fbb09c57b4ce8edf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

