### PR TITLE
Wallet Connect: Beta Feature Field

### DIFF
--- a/src/beta.ts
+++ b/src/beta.ts
@@ -121,6 +121,10 @@ function stripEip155Prefix(eip155Address: string): string {
   return eip155Address.split(":").pop() ?? "";
 }
 
+/**
+ * Features currently underdevelopment that will be migrated into the adapter class once refined.
+ * These features are accessible through the adapter class as `adapter.beta.methodName(...)`
+ */
 export class Beta {
   adapter: NearEthAdapter;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ export * from "./types";
 export * from "./utils/signature";
 export * from "./network";
 export * from "./utils/transaction";
+/// Beta features
+export * from "./beta";
 
 /**
  * Configuration for setting up the adapter.

--- a/tests/unit/ethereum.test.ts
+++ b/tests/unit/ethereum.test.ts
@@ -31,7 +31,7 @@ describe("ethereum", () => {
     expect(request.actions.length).toEqual(1);
 
     expect(() =>
-      adapter.handleSessionRequest({
+      adapter.beta.handleSessionRequest({
         params: {
           chainId: "11155111",
           request: { method: "poop", params: [] },
@@ -39,7 +39,7 @@ describe("ethereum", () => {
       })
     ).rejects.toThrow("Unhandled session_request method: poop");
 
-    const ethSign = await adapter.handleSessionRequest({
+    const ethSign = await adapter.beta.handleSessionRequest({
       params: {
         chainId: "11155111",
         request: {

--- a/tests/unit/wc.handlers.test.ts
+++ b/tests/unit/wc.handlers.test.ts
@@ -1,28 +1,18 @@
-import { TransactionSerializable, toHex } from "viem";
-import {
-  EthTransactionParams,
-  PersonalSignParams,
-  wcRouter,
-} from "../../src/wallet-connect/handlers";
+import { Hex, TransactionSerializable, toHex } from "viem";
+import { wcRouter } from "../../src/beta";
 
 describe("Wallet Connect", () => {
   const chainId = "eip155:11155111";
-  const from = "0xa61d98854f7ab25402e3d12548a2e93a080c1f97";
-  const to = "0xfff9976782d46cc05630d1f6ebab18b2324d6b14";
+  const from = "0xa61d98854f7ab25402e3d12548a2e93a080c1f97" as Hex;
+  const to = "0xfff9976782d46cc05630d1f6ebab18b2324d6b14" as Hex;
 
   describe("wcRouter: eth_sign & personal_sign", () => {
     it("hello message", async () => {
       const messageString = "Hello!";
-      const request = {
-        method: "eth_sign",
-        params: [from, toHex(messageString)],
-      };
-
-      const { evmMessage, payload } = await wcRouter(
-        request.method,
-        chainId,
-        request.params as PersonalSignParams
-      );
+      const { evmMessage, payload } = await wcRouter("eth_sign", chainId, [
+        from,
+        toHex(messageString),
+      ]);
       expect(evmMessage).toEqual(messageString);
       expect(payload).toEqual([
         82, 182, 67, 125, 181, 109, 135, 245, 153, 29, 124, 23, 60, 241, 27,
@@ -33,30 +23,16 @@ describe("Wallet Connect", () => {
 
     it("fail with wrong method", async () => {
       const messageString = "Hello!";
-      const request = {
-        method: "eth_fail",
-        params: [from, toHex(messageString)],
-      };
-
       await expect(
-        wcRouter(request.method, chainId, request.params as PersonalSignParams)
+        wcRouter("eth_fail", chainId, [from, toHex(messageString)])
       ).rejects.toThrow("Unhandled session_request method: eth_fail");
     });
 
     it("opensea login", async () => {
-      const request = {
-        method: "personal_sign",
-        params: [
-          "0x57656c636f6d6520746f204f70656e536561210a0a436c69636b20746f207369676e20696e20616e642061636365707420746865204f70656e536561205465726d73206f662053657276696365202868747470733a2f2f6f70656e7365612e696f2f746f732920616e64205072697661637920506f6c696379202868747470733a2f2f6f70656e7365612e696f2f70726976616379292e0a0a5468697320726571756573742077696c6c206e6f742074726967676572206120626c6f636b636861696e207472616e73616374696f6e206f7220636f737420616e792067617320666565732e0a0a57616c6c657420616464726573733a0a3078663131633232643631656364376231616463623662343335343266653861393662393332386463370a0a4e6f6e63653a0a32393731633731312d623739382d343433342d613633312d316333663133656665353365",
-          "0xf11c22d61ecd7b1adcb6b43542fe8a96b9328dc7",
-        ],
-      };
-
-      const { evmMessage, payload } = await wcRouter(
-        request.method,
-        chainId,
-        request.params as PersonalSignParams
-      );
+      const { evmMessage, payload } = await wcRouter("personal_sign", chainId, [
+        "0x57656c636f6d6520746f204f70656e536561210a0a436c69636b20746f207369676e20696e20616e642061636365707420746865204f70656e536561205465726d73206f662053657276696365202868747470733a2f2f6f70656e7365612e696f2f746f732920616e64205072697661637920506f6c696379202868747470733a2f2f6f70656e7365612e696f2f70726976616379292e0a0a5468697320726571756573742077696c6c206e6f742074726967676572206120626c6f636b636861696e207472616e73616374696f6e206f7220636f737420616e792067617320666565732e0a0a57616c6c657420616464726573733a0a3078663131633232643631656364376231616463623662343335343266653861393662393332386463370a0a4e6f6e63653a0a32393731633731312d623739382d343433342d613633312d316333663133656665353365",
+        "0xf11c22d61ecd7b1adcb6b43542fe8a96b9328dc7",
+      ]);
       expect(evmMessage).toEqual(
         `Welcome to OpenSea!
 
@@ -78,19 +54,10 @@ Nonce:
     });
 
     it("manifold login", async () => {
-      const request = {
-        method: "personal_sign",
-        params: [
-          "0x506c65617365207369676e2074686973206d65737361676520746f20616363657373204d616e69666f6c642053747564696f0a0a4368616c6c656e67653a2034313133666333616232636336306635643539356232653535333439663165656335366664306337306434323837303831666537313536383438323633363236",
-          "0xf11c22d61ecd7b1adcb6b43542fe8a96b9328dc7",
-        ],
-      };
-
-      const { evmMessage, payload } = await wcRouter(
-        request.method,
-        chainId,
-        request.params as PersonalSignParams
-      );
+      const { evmMessage, payload } = await wcRouter("personal_sign", chainId, [
+        "0x506c65617365207369676e2074686973206d65737361676520746f20616363657373204d616e69666f6c642053747564696f0a0a4368616c6c656e67653a2034313133666333616232636336306635643539356232653535333439663165656335366664306337306434323837303831666537313536383438323633363236",
+        "0xf11c22d61ecd7b1adcb6b43542fe8a96b9328dc7",
+      ]);
       expect(evmMessage).toEqual(
         `Please sign this message to access Manifold Studio
 
@@ -105,24 +72,15 @@ Challenge: 4113fc3ab2cc60f5d595b2e55349f1eec56fd0c70d4287081fe7156848263626`
   });
   describe("wcRouter: eth_sendTransaction", () => {
     it("with value", async () => {
-      const request = {
-        method: "eth_sendTransaction",
-        params: [
-          {
-            gas: "0xd31d",
-            value: "0x16345785d8a0000",
-            from,
-            to,
-            data: "0xd0e30db0",
-          },
-        ],
-      };
-
-      const { evmMessage } = await wcRouter(
-        request.method,
-        chainId,
-        request.params as EthTransactionParams[]
-      );
+      const { evmMessage } = await wcRouter("eth_sendTransaction", chainId, [
+        {
+          gas: "0xd31d",
+          value: "0x16345785d8a0000",
+          from,
+          to,
+          data: "0xd0e30db0",
+        },
+      ]);
       const tx = evmMessage as TransactionSerializable;
 
       delete tx.maxFeePerGas;
@@ -141,23 +99,14 @@ Challenge: 4113fc3ab2cc60f5d595b2e55349f1eec56fd0c70d4287081fe7156848263626`
     });
 
     it("null value", async () => {
-      const request = {
-        method: "eth_sendTransaction",
-        params: [
-          {
-            gas: "0xa8c3",
-            from,
-            to,
-            data: "0x2e1a7d4d000000000000000000000000000000000000000000000000002386f26fc10000",
-          },
-        ],
-      };
-
-      const { evmMessage } = await wcRouter(
-        request.method,
-        chainId,
-        request.params as EthTransactionParams[]
-      );
+      const { evmMessage } = await wcRouter("eth_sendTransaction", chainId, [
+        {
+          gas: "0xa8c3",
+          from,
+          to,
+          data: "0x2e1a7d4d000000000000000000000000000000000000000000000000002386f26fc10000",
+        },
+      ]);
       const tx = evmMessage as TransactionSerializable;
 
       delete tx.maxFeePerGas;
@@ -176,23 +125,14 @@ Challenge: 4113fc3ab2cc60f5d595b2e55349f1eec56fd0c70d4287081fe7156848263626`
     });
 
     it("null data", async () => {
-      const request = {
-        method: "eth_sendTransaction",
-        params: [
-          {
-            gas: "0xa8c3",
-            from,
-            to,
-            value: "0x01",
-          },
-        ],
-      };
-
-      const { evmMessage } = await wcRouter(
-        request.method,
-        chainId,
-        request.params as EthTransactionParams[]
-      );
+      const { evmMessage } = await wcRouter("eth_sendTransaction", chainId, [
+        {
+          gas: "0xa8c3",
+          from,
+          to,
+          value: "0x01",
+        },
+      ]);
       const tx = evmMessage as TransactionSerializable;
 
       delete tx.maxFeePerGas;
@@ -249,9 +189,9 @@ Challenge: 4113fc3ab2cc60f5d595b2e55349f1eec56fd0c70d4287081fe7156848263626`
       };
 
       const { evmMessage, payload } = await wcRouter(
-        request.method,
+        "eth_signTypedData_v4",
         chainId,
-        request.params as PersonalSignParams
+        [from, jsonStr]
       );
       expect(evmMessage).toEqual(request.params[1]);
       expect(payload).toEqual([


### PR DESCRIPTION
### **User description**
The wallet connect stuff isn't being used so much at the moment and it will take a while to refine the interfaces.
This PR proposes that we put these features under a beta field:

```ts
class Beta {
  handleSessionRequest() {
    console.log("This is a beta feature");
  }
  respondSessionRequest() {
    console.log("This is a beta feature");
  }
}

class EthAdapter {
  constructor() {
    this.beta = new Beta();
  }

  stableMethod() {
    console.log("This is a stable method");
  }
}

const adapter = new EthAdapter();
adapter.stableMethod(); // Output: "This is a stable method"
adapter.beta.handleSessionRequest(); // Output: "This is a beta feature"
adapter.beta.respondSessionRequest();
```


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced a new `Beta` class to handle session requests and responses, encapsulating beta features.
- Integrated the `Beta` class into the `NearEthAdapter`, removing the session handling methods from the adapter itself.
- Updated unit tests to utilize the new `Beta` class for session handling.
- Refactored Wallet Connect handler tests to use the `wcRouter` from `beta.ts` and simplified test cases.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>beta.ts</strong><dd><code>Introduce `Beta` class for session handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/beta.ts

<li>Added <code>Beta</code> class to handle session requests and responses.<br> <li> Imported additional modules and types.<br> <li> Refactored <code>wcRouter</code> function to include new data handling.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/93/files#diff-3a1f1afbd4b8e47616b4f8376ff2edc87202e2eb9e1e07a642178a463efa1dc3">+57/-8</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ethereum.ts</strong><dd><code>Integrate `Beta` class into `NearEthAdapter`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/chains/ethereum.ts

<li>Integrated <code>Beta</code> class into <code>NearEthAdapter</code>.<br> <li> Removed session handling methods from <code>NearEthAdapter</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/93/files#diff-9cae2980092ecb69c0204c332224ce902083c2eea7ac9a084f296c16d4714510">+6/-51</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ethereum.test.ts</strong><dd><code>Update tests to use `Beta` class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/ethereum.test.ts

- Updated tests to use `Beta` class for session handling.



</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/93/files#diff-cba622b6a59a60d7696f30afdb543b7e423c52b03335f46290f98db9f6b16892">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>wc.handlers.test.ts</strong><dd><code>Refactor Wallet Connect handler tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/wc.handlers.test.ts

<li>Refactored tests to use <code>wcRouter</code> from <code>beta.ts</code>.<br> <li> Simplified test cases for session request handling.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/93/files#diff-8367729fc869e28eaa3bbcebebc093d58ce74f39d43722b934778f7f781a04d7">+44/-104</a></td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

