### PR TITLE
Extract Relayed Signatures

### DIFF
--- a/src/utils/signature.ts
+++ b/src/utils/signature.ts
@@ -86,8 +86,8 @@ export function signatureFromOutcome(
     b64Sig = outcome.receipts_outcome
       // Map to get SuccessValues: The Signature will appear twice.
       .map(
-        (outcome) =>
-          (outcome.outcome.status as FinalExecutionStatus).SuccessValue
+        (receipt) =>
+          (receipt.outcome.status as FinalExecutionStatus).SuccessValue
       )
       // Reverse the to "find" the last non-empty value!
       .reverse()

--- a/tests/unit/utils.signature.test.ts
+++ b/tests/unit/utils.signature.test.ts
@@ -8,13 +8,20 @@ describe("utility: get Signature", () => {
   const url: string = "https://archival-rpc.testnet.near.org";
   // const accountId = "neareth-dev.testnet";
   const successHash = "GeqmwWmWxddzh2yCEhugbJkhzsJMhCuFyQZa61w5dk7N";
+  const relayedSuccessHash = "G1f1HVUxDBWXAEimgNWobQ9yCx1EgA2tzYHJBFUfo3dj";
   const failedHash = "6yRm5FjHn9raRYPoHH6wimizhT53PnPnuvkpecyQDqLY";
 
-  it("successful: signatureFromTxHash", async () => {
+  it.only("successful: signatureFromTxHash", async () => {
     const sig = await signatureFromTxHash(url, successHash);
     expect(sig).toEqual({
       r: "0x3BA6A8CE1369484EF384084EC1089581D815260FC274FEF780478C7969F3CFFC",
       s: "0x5194CCE1D9F239C28C7765453873A07F35850A485DFE285551FB62C899B61170",
+      yParity: 1,
+    });
+    const relayedSig = await signatureFromTxHash(url, relayedSuccessHash);
+    expect(relayedSig).toEqual({
+      r: "0x593873A56AB98F91C60C23DCA370835CA05254A0305F2753A1CFC3CEB4C46F86",
+      s: "0x783D9887FB4AA9B07E672D7FA88587FB45E7FDC066F7ECA0774E6FE36806404F",
       yParity: 1,
     });
   });
@@ -56,6 +63,20 @@ describe("utility: get Signature", () => {
       status: {
         SuccessValue:
           "eyJiaWdfciI6eyJhZmZpbmVfcG9pbnQiOiIwMkVBRDJCMUYwN0NDNDk4REIyNTU2MzE0QTZGNzdERkUzRUUzRDE0NTNCNkQ3OTJBNzcwOTE5MjRFNTFENEMyNDcifSwicyI6eyJzY2FsYXIiOiIxQTlGNjBDMkNDMjM5OEE1MDk3N0Q0Q0E5M0M0MDE2OEU4RjJDRTdBOUM5MEUzNzQ1MjJERjNDNzZDRjU0RjJFIn0sInJlY292ZXJ5X2lkIjoxfQ==",
+      },
+      // irrelevant fields
+      receipts_outcome: [],
+      transaction: null,
+      transaction_outcome: {
+        id: "",
+        outcome: {
+          logs: [],
+          receipt_ids: [],
+          gas_burnt: 0,
+          tokens_burnt: "",
+          executor_id: "string",
+          status: {},
+        },
       },
     };
     expect(signatureFromOutcome(outcome)).toEqual({

--- a/tests/unit/utils.signature.test.ts
+++ b/tests/unit/utils.signature.test.ts
@@ -10,6 +10,9 @@ describe("utility: get Signature", () => {
   const successHash = "GeqmwWmWxddzh2yCEhugbJkhzsJMhCuFyQZa61w5dk7N";
   const relayedSuccessHash = "G1f1HVUxDBWXAEimgNWobQ9yCx1EgA2tzYHJBFUfo3dj";
   const failedHash = "6yRm5FjHn9raRYPoHH6wimizhT53PnPnuvkpecyQDqLY";
+  const nonExistantTxHash = "7yRm5FjHn9raRYPoHH6wimizhT53PnPnuvkpecyQDqLY";
+  const nonSignatureRequestHash =
+    "4pNDN238dgEjj5eNaAF4qzoztF4TmrN82hwJs2zTwuqe";
 
   it("successful: signatureFromTxHash", async () => {
     const sig = await signatureFromTxHash(url, successHash);
@@ -27,9 +30,24 @@ describe("utility: get Signature", () => {
     });
   });
 
-  it("signatureFromTxHash fails with no signature", async () => {
+  it("signatureFromTxHash fails Error", async () => {
     await expect(signatureFromTxHash(url, failedHash)).rejects.toThrow(
-      `No detectable signature found in transaction ${failedHash}`
+      `Signature Request Failed in ${failedHash}`
+    );
+  });
+
+  it("signatureFromTxHash fails with no signature", async () => {
+    await expect(
+      signatureFromTxHash(url, nonSignatureRequestHash)
+    ).rejects.toThrow(
+      `No detectable signature found in transaction ${nonSignatureRequestHash}`
+    );
+  });
+
+  // This one takes too long.
+  it.skip("signatureFromTxHash fails with server error", async () => {
+    await expect(signatureFromTxHash(url, nonExistantTxHash)).rejects.toThrow(
+      "JSON-RPC error: Server error"
     );
   });
 

--- a/tests/unit/utils.signature.test.ts
+++ b/tests/unit/utils.signature.test.ts
@@ -11,13 +11,14 @@ describe("utility: get Signature", () => {
   const relayedSuccessHash = "G1f1HVUxDBWXAEimgNWobQ9yCx1EgA2tzYHJBFUfo3dj";
   const failedHash = "6yRm5FjHn9raRYPoHH6wimizhT53PnPnuvkpecyQDqLY";
 
-  it.only("successful: signatureFromTxHash", async () => {
+  it("successful: signatureFromTxHash", async () => {
     const sig = await signatureFromTxHash(url, successHash);
     expect(sig).toEqual({
       r: "0x3BA6A8CE1369484EF384084EC1089581D815260FC274FEF780478C7969F3CFFC",
       s: "0x5194CCE1D9F239C28C7765453873A07F35850A485DFE285551FB62C899B61170",
       yParity: 1,
     });
+
     const relayedSig = await signatureFromTxHash(url, relayedSuccessHash);
     expect(relayedSig).toEqual({
       r: "0x593873A56AB98F91C60C23DCA370835CA05254A0305F2753A1CFC3CEB4C46F86",


### PR DESCRIPTION
### **User description**
[This transaction](https://testnet.nearblocks.io/txns/G1f1HVUxDBWXAEimgNWobQ9yCx1EgA2tzYHJBFUfo3dj?tab=execution) was relayed by `mintbase.testnet` on behalf of `neareth-dev.testnet`. The signature is nested deep inside the transaction instead of on the outer `successValue`.

We introduce a method for digging out the signature from the receipt that is compatible with both scenarios.

Still need to verify that signatures are indeed valid.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced the `signatureFromOutcome` function to support the extraction of signatures from relayed transactions by digging into nested receipts.
- Added unit tests to verify the new extraction logic for relayed transactions.
- Updated existing tests to ensure compatibility with the new changes.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signature.ts</strong><dd><code>Enhance signature extraction to support relayed transactions</code></dd></summary>
<hr>

src/utils/signature.ts

<li>Added logic to handle relayed transactions by extracting signatures <br>from nested receipts.<br> <li> Introduced a check for empty <code>SuccessValue</code> and subsequent extraction <br>from <code>receipts_outcome</code>.<br> <li> Updated the <code>signatureFromOutcome</code> function to support both direct and <br>relayed transactions.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/94/files#diff-0dcd6c8a6f6ba88fa3b6994d7e4594fe15879dd55b386d9663abe17b02b0501a">+20/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>utils.signature.test.ts</strong><dd><code>Add unit tests for relayed transaction signature extraction</code></dd></summary>
<hr>

tests/unit/utils.signature.test.ts

<li>Added test case for relayed transaction signature extraction.<br> <li> Verified the extraction logic for both direct and relayed <br>transactions.<br> <li> Included additional test data for relayed transactions.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/94/files#diff-d6587b10831e36ea2f2e8468588145cf4b32b302e0940ad5c01a85846fd6a175">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

