### PR TITLE
Beta: Simplify Wallet Connect

### DIFF
--- a/tests/unit/wc.handlers.test.ts
+++ b/tests/unit/wc.handlers.test.ts
@@ -1,4 +1,4 @@
-import { Hex, TransactionSerializable, toHex } from "viem";
+import { Hex, isHex, toHex } from "viem";
 import { wcRouter } from "../../src/beta";
 
 describe("Wallet Connect", () => {
@@ -71,6 +71,7 @@ Challenge: 4113fc3ab2cc60f5d595b2e55349f1eec56fd0c70d4287081fe7156848263626`
     });
   });
   describe("wcRouter: eth_sendTransaction", () => {
+    /// can't test payload: its non-deterministic because of gas values!
     it("with value", async () => {
       const { evmMessage } = await wcRouter("eth_sendTransaction", chainId, [
         {
@@ -81,21 +82,7 @@ Challenge: 4113fc3ab2cc60f5d595b2e55349f1eec56fd0c70d4287081fe7156848263626`
           data: "0xd0e30db0",
         },
       ]);
-      const tx = evmMessage as TransactionSerializable;
-
-      delete tx.maxFeePerGas;
-      delete tx.maxPriorityFeePerGas;
-      delete tx.nonce;
-
-      expect(tx).toEqual({
-        account: from,
-        chainId: 11155111,
-        data: "0xd0e30db0",
-        gas: 54045n,
-        to,
-        value: 100000000000000000n,
-      });
-      /// can't test payload: its non-deterministic because of gas values!
+      expect(isHex(evmMessage)).toBe(true);
     });
 
     it("null value", async () => {
@@ -107,21 +94,8 @@ Challenge: 4113fc3ab2cc60f5d595b2e55349f1eec56fd0c70d4287081fe7156848263626`
           data: "0x2e1a7d4d000000000000000000000000000000000000000000000000002386f26fc10000",
         },
       ]);
-      const tx = evmMessage as TransactionSerializable;
 
-      delete tx.maxFeePerGas;
-      delete tx.maxPriorityFeePerGas;
-      delete tx.nonce;
-
-      expect(tx).toEqual({
-        account: from,
-        chainId: 11155111,
-        data: "0x2e1a7d4d000000000000000000000000000000000000000000000000002386f26fc10000",
-        gas: 43203n,
-        to,
-        value: 0n,
-      });
-      /// can't test payload: its non-deterministic because of gas values!
+      expect(isHex(evmMessage)).toBe(true);
     });
 
     it("null data", async () => {
@@ -133,21 +107,8 @@ Challenge: 4113fc3ab2cc60f5d595b2e55349f1eec56fd0c70d4287081fe7156848263626`
           value: "0x01",
         },
       ]);
-      const tx = evmMessage as TransactionSerializable;
 
-      delete tx.maxFeePerGas;
-      delete tx.maxPriorityFeePerGas;
-      delete tx.nonce;
-
-      expect(tx).toEqual({
-        account: from,
-        chainId: 11155111,
-        data: "0x",
-        gas: 43203n,
-        to,
-        value: 1n,
-      });
-      /// can't test payload: its non-deterministic because of gas values!
+      expect(isHex(evmMessage)).toBe(true);
     });
   });
   describe("wcRouter: eth_signTypedData", () => {


### PR DESCRIPTION
### **User description**
1. serialize `evmMessage` in case of `eth_sendTransaction` so that front ends dont have to 
```ts
const txData = await this.beta.handleSessionRequest(request);
if (typeof txData.evmMessage !== "string") {
  txData.evmMessage = serializeTransaction(txData.evmMessage);
}
```
for rendering data.

2. Simplify `respondSessionRequest` with optional txHex which implies it should be added to the signature.


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Simplified the handling of `evmMessage` by ensuring it is always serialized within the `wcRouter` function.
- Updated the `respondSessionRequest` method to optionally accept a transaction, streamlining the signature process.
- Enhanced unit tests to verify that `evmMessage` is a hex string, removing the need for detailed transaction property checks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>beta.ts</strong><dd><code>Simplify transaction handling and serialization in `wcRouter`</code></dd></summary>
<hr>

src/beta.ts

<li>Removed <code>TransactionSerializable</code> type for <code>evmMessage</code>.<br> <li> Serialized <code>evmMessage</code> directly within <code>wcRouter</code>.<br> <li> Simplified <code>respondSessionRequest</code> by making <code>transaction</code> optional.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/95/files#diff-3a1f1afbd4b8e47616b4f8376ff2edc87202e2eb9e1e07a642178a463efa1dc3">+8/-11</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wc.handlers.test.ts</strong><dd><code>Update tests for simplified transaction handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/unit/wc.handlers.test.ts

<li>Updated tests to check if <code>evmMessage</code> is a hex string.<br> <li> Removed detailed transaction property checks.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/95/files#diff-8367729fc869e28eaa3bbcebebc093d58ce74f39d43722b934778f7f781a04d7">+5/-44</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

