### PR TITLE
HotFix: requestRouter eth_sendTransaction Hex Parsing

### DIFF
--- a/src/utils/request.ts
+++ b/src/utils/request.ts
@@ -68,11 +68,11 @@ export async function requestRouter({
     }
     case "eth_sendTransaction": {
       // We only support one transaction at a time!
-      const tx = params[0] as EthTransactionParams;
       let rlpTx: Hex;
-      if (isHex(tx)) {
-        rlpTx = tx;
+      if (isHex(params)) {
+        rlpTx = params;
       } else {
+        const tx = params[0] as EthTransactionParams;
         const transaction = await populateTx(
           {
             to: tx.to,


### PR DESCRIPTION
### **User description**
We had been falsely assuming that params was an array when it was Hex


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue in the `requestRouter` function where hex parsing for `eth_sendTransaction` was incorrectly assuming `params` was an array.
- Changed the hex validation to check `params` directly instead of `tx`.
- Moved the extraction of the transaction object from `params` inside the else block to ensure proper handling.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>request.ts</strong><dd><code>Fix hex parsing in `eth_sendTransaction` request handling</code></dd></summary>
<hr>

src/utils/request.ts

<li>Fixed hex parsing logic in <code>eth_sendTransaction</code> case.<br> <li> Changed the check from <code>tx</code> to <code>params</code> for hex validation.<br> <li> Moved the extraction of <code>tx</code> from <code>params</code> inside the else block.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/113/files#diff-ec5a1223686ea9c57fb3593ca303c83c06211b8ca65d8080a1ef77610c898ddb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

