### PR TITLE
Easy: no warning when unnecessary

### DIFF
--- a/src/mpcContract.ts
+++ b/src/mpcContract.ts
@@ -88,10 +88,11 @@ export class MpcContract {
       ) {
         // Clown town
         deposit = await this.contract.experimantal_signature_deposit();
+      } else {
+        console.warn(
+          `Failed to get deposit with ${error} - using fallback of 0.1 Near`
+        );
       }
-      console.warn(
-        `Failed to get deposit with ${error} - using fallback of 0.1 Near`
-      );
     }
     return BigInt(
       deposit.toLocaleString("fullwide", { useGrouping: false })


### PR DESCRIPTION
### **User description**
We were seeing this warning even upon capturing the incorrectly spelled method name.


___

### **PR Type**
bug fix


___

### **Description**
- Adjusted the logic for displaying a warning message in `MpcContract` to ensure it only appears when the error is not "Contract method is not found".
- Moved the warning message inside the `else` block to prevent unnecessary warnings.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>mpcContract.ts</strong><dd><code>Adjust warning message logic in `MpcContract`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/mpcContract.ts

<li>Moved the warning message inside the <code>else</code> block.<br> <li> Ensured the warning only appears when the error is not "Contract <br>method is not found".<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/115/files#diff-33ca61c8ff12b936fbd01e28c03dd6076be6f78ce96ab42f19e117a64413e461">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

