### PR TITLE
Alphabetize and add testnet flag to CHAIN_INFO

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,69 +3,69 @@ const ETHER_ICON = "https://cryptologos.cc/logos/ethereum-eth-logo.svg?v=024";
 
 export const CHAIN_INFO: {
   [key: number]: {
-    icon?: string;
-    wrappedToken: string;
     currencyIcon?: string;
+    icon?: string;
     testnet: boolean;
+    wrappedToken: string;
   };
 } = {
   1: {
     icon: ETHER_ICON,
-    wrappedToken: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     testnet: false,
+    wrappedToken: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
   },
   10: {
-    icon: "https://cryptologos.cc/logos/optimism-ethereum-op-logo.svg?v=024",
-    wrappedToken: "0x4200000000000000000000000000000000000006",
     currencyIcon: ETHER_ICON,
+    icon: "https://cryptologos.cc/logos/optimism-ethereum-op-logo.svg?v=024",
     testnet: false,
+    wrappedToken: "0x4200000000000000000000000000000000000006",
   },
   56: {
     icon: "https://cryptologos.cc/logos/binance-coin-bnb-logo.svg?v=024",
-    wrappedToken: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
     testnet: false,
+    wrappedToken: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
   },
   97: {
     icon: "https://cryptologos.cc/logos/binance-coin-bnb-logo.svg?v=024",
-    wrappedToken: "0x094616f0bdfb0b526bd735bf66eca0ad254ca81f",
     testnet: true,
+    wrappedToken: "0x094616f0bdfb0b526bd735bf66eca0ad254ca81f",
   },
   100: {
-    icon: "https://cryptologos.cc/logos/gnosis-gno-gno-logo.svg?v=002",
-    wrappedToken: "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
     currencyIcon: "https://docs.gnosischain.com/img/tokens/xdai.png",
+    icon: "https://cryptologos.cc/logos/gnosis-gno-gno-logo.svg?v=002",
     testnet: false,
+    wrappedToken: "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
   },
   137: {
     icon: "https://cryptologos.cc/logos/polygon-matic-logo.svg?v=024",
-    wrappedToken: "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
     testnet: false,
+    wrappedToken: "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
   },
   8453: {
-    icon: "https://avatars.githubusercontent.com/u/108554348?s=48&v=4",
-    wrappedToken: "0x4200000000000000000000000000000000000006",
     currencyIcon: ETHER_ICON,
+    icon: "https://avatars.githubusercontent.com/u/108554348?s=48&v=4",
     testnet: false,
+    wrappedToken: "0x4200000000000000000000000000000000000006",
   },
   42161: {
+    currencyIcon: ETHER_ICON,
     icon: "https://cryptologos.cc/logos/arbitrum-arb-logo.svg?v=024",
     wrappedToken: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
-    currencyIcon: ETHER_ICON,
     testnet: true,
   },
   84532: {
-    wrappedToken: "0x4200000000000000000000000000000000000006",
     currencyIcon: ETHER_ICON,
+    wrappedToken: "0x4200000000000000000000000000000000000006",
     testnet: true,
   },
   421614: {
     currencyIcon: ETHER_ICON,
-    wrappedToken: "0x980b62da83eff3d4576c647993b0c1d7faf17c73",
     testnet: true,
+    wrappedToken: "0x980b62da83eff3d4576c647993b0c1d7faf17c73",
   },
   11155111: {
     icon: ETHER_ICON,
-    wrappedToken: "0xD0A1E359811322d97991E03f863a0C30C2cF029C",
     testnet: true,
+    wrappedToken: "0xD0A1E359811322d97991E03f863a0C30C2cF029C",
   },
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,14 +1,12 @@
 /// A short list of networks with known wrapped tokens.
 const ETHER_ICON = "https://cryptologos.cc/logos/ethereum-eth-logo.svg?v=024";
-
-export const CHAIN_INFO: {
-  [key: number]: {
-    currencyIcon?: string;
-    icon?: string;
-    testnet: boolean;
-    wrappedToken: string;
-  };
-} = {
+interface ChainInfo {
+  currencyIcon?: string;
+  icon?: string;
+  testnet: boolean;
+  wrappedToken: string;
+}
+export const CHAIN_INFO: Record<number, ChainInfo> = {
   1: {
     icon: ETHER_ICON,
     testnet: false,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,42 +2,70 @@
 const ETHER_ICON = "https://cryptologos.cc/logos/ethereum-eth-logo.svg?v=024";
 
 export const CHAIN_INFO: {
-  [key: number]: { icon?: string; wrappedToken: string; currencyIcon?: string };
+  [key: number]: {
+    icon?: string;
+    wrappedToken: string;
+    currencyIcon?: string;
+    testnet: boolean;
+  };
 } = {
-  11155111: {
-    icon: ETHER_ICON,
-    wrappedToken: "0xD0A1E359811322d97991E03f863a0C30C2cF029C",
-  },
   1: {
     icon: ETHER_ICON,
     wrappedToken: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-  },
-  100: {
-    icon: "https://cryptologos.cc/logos/gnosis-gno-gno-logo.svg?v=002",
-    wrappedToken: "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
-    currencyIcon: "https://docs.gnosischain.com/img/tokens/xdai.png",
-  },
-  137: {
-    icon: "https://cryptologos.cc/logos/polygon-matic-logo.svg?v=024",
-    wrappedToken: "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
-  },
-  42161: {
-    icon: "https://cryptologos.cc/logos/arbitrum-arb-logo.svg?v=024",
-    wrappedToken: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
-    currencyIcon: ETHER_ICON,
+    testnet: false,
   },
   10: {
     icon: "https://cryptologos.cc/logos/optimism-ethereum-op-logo.svg?v=024",
     wrappedToken: "0x4200000000000000000000000000000000000006",
     currencyIcon: ETHER_ICON,
+    testnet: false,
+  },
+  56: {
+    icon: "https://cryptologos.cc/logos/binance-coin-bnb-logo.svg?v=024",
+    wrappedToken: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+    testnet: false,
+  },
+  97: {
+    icon: "https://cryptologos.cc/logos/binance-coin-bnb-logo.svg?v=024",
+    wrappedToken: "0x094616f0bdfb0b526bd735bf66eca0ad254ca81f",
+    testnet: true,
+  },
+  100: {
+    icon: "https://cryptologos.cc/logos/gnosis-gno-gno-logo.svg?v=002",
+    wrappedToken: "0x6a023ccd1ff6f2045c3309768ead9e68f978f6e1",
+    currencyIcon: "https://docs.gnosischain.com/img/tokens/xdai.png",
+    testnet: false,
+  },
+  137: {
+    icon: "https://cryptologos.cc/logos/polygon-matic-logo.svg?v=024",
+    wrappedToken: "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+    testnet: false,
   },
   8453: {
     icon: "https://avatars.githubusercontent.com/u/108554348?s=48&v=4",
     wrappedToken: "0x4200000000000000000000000000000000000006",
     currencyIcon: ETHER_ICON,
+    testnet: false,
   },
-  56: {
-    icon: "https://cryptologos.cc/logos/binance-coin-bnb-logo.svg?v=024",
-    wrappedToken: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
+  42161: {
+    icon: "https://cryptologos.cc/logos/arbitrum-arb-logo.svg?v=024",
+    wrappedToken: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
+    currencyIcon: ETHER_ICON,
+    testnet: true,
+  },
+  84532: {
+    wrappedToken: "0x4200000000000000000000000000000000000006",
+    currencyIcon: ETHER_ICON,
+    testnet: true,
+  },
+  421614: {
+    currencyIcon: ETHER_ICON,
+    wrappedToken: "0x980b62da83eff3d4576c647993b0c1d7faf17c73",
+    testnet: true,
+  },
+  11155111: {
+    icon: ETHER_ICON,
+    wrappedToken: "0xD0A1E359811322d97991E03f863a0C30C2cF029C",
+    testnet: true,
   },
 };


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added a `testnet` boolean flag to each network entry in the `CHAIN_INFO` object to distinguish between testnets and mainnets.
- Reordered the network entries in `CHAIN_INFO` alphabetically by their network ID.
- Included new network entries with their respective icons and wrapped tokens.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Enhance and reorder `CHAIN_INFO` with testnet flag and new entries</code></dd></summary>
<hr>

src/constants.ts

<li>Added <code>testnet</code> flag to each network entry in <code>CHAIN_INFO</code>.<br> <li> Alphabetized the network entries.<br> <li> Added new network entries with their respective icons and wrapped <br>tokens.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/119/files#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199">+41/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

