### PR TITLE
Arbitrum is not a Testnet

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -49,7 +49,7 @@ export const CHAIN_INFO: Record<number, ChainInfo> = {
     currencyIcon: ETHER_ICON,
     icon: "https://cryptologos.cc/logos/arbitrum-arb-logo.svg?v=024",
     wrappedToken: "0x82af49447d8a07e3bd95bd0d56f35241523fbab1",
-    testnet: true,
+    testnet: false,
   },
   84532: {
     currencyIcon: ETHER_ICON,

--- a/tests/unit/utils.signature.test.ts
+++ b/tests/unit/utils.signature.test.ts
@@ -53,7 +53,7 @@ describe("utility: get Signature", () => {
 
   it("signatureFromTxHash fails with parse error", async () => {
     await expect(signatureFromTxHash(url, "nonsense")).rejects.toThrow(
-      "JSON-RPC error: Parse error"
+      "HTTP error! status: 400"
     );
   });
 


### PR DESCRIPTION
### **User description**
This was accidentally marked as a testnet.


___

### **PR Type**
bug_fix


___

### **Description**
- Corrected the `testnet` status for the Arbitrum chain in the `CHAIN_INFO` object from `true` to `false`, ensuring accurate network classification.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>constants.ts</strong><dd><code>Fix incorrect testnet status for Arbitrum in constants</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/constants.ts

<li>Corrected the <code>testnet</code> status for Arbitrum from <code>true</code> to <code>false</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/Mintbase/near-ca/pull/126/files#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

